### PR TITLE
Fix documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-incident-management/master.svg)](https://codecov.io/gh/mattermost/mattermost-plugin-incident-management)
 [![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-incident-management)](https://github.com/mattermost/mattermost-plugin-incident-management/releases/latest)
 
-Mattermost Incident Management allows your team to coordinate, manage, and resolve incidents from within Mattermost. For configuration and administration information visit our [documentation](https://mattermost.gitbook.io/incident-management-plugin/).
+Mattermost Incident Management allows your team to coordinate, manage, and resolve incidents from within Mattermost. For configuration and administration information visit our [documentation](https://mattermost.gitbook.io/mattermost-incident-management/).
 
 ![Mattermost Incident Management](docs/assets/incident_response_landing.png)
 
@@ -22,4 +22,4 @@ This plugin contains both a server and web app portion. Read our documentation a
 
 For more information about contributing to Mattermost, and the different ways you can contribute, see https://www.mattermost.org/contribute-to-mattermost.
 
-Please visit the [Mattermost Incident Management developer docs](https://mattermost.gitbook.io/incident-management-plugin/development/contributing) to learn more about contributing.
+Please visit the [Mattermost Incident Management developer docs](https://mattermost.gitbook.io/mattermost-incident-management/development/contributing) to learn more about contributing.


### PR DESCRIPTION
#### Summary
I broke the docs links while renaming everything. I think we should merge this prior to v1.1 release.

#### Ticket Link
--

