### PR TITLE
MM-30207 - include playbook id in telemetry; bump to v1.1.1

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
     "description": "This plugin allows users to coordinate and manage incidents within Mattermost.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-incident-response/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-incident-response/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-incident-response/releases/tag/v1.1.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-incident-response/releases/tag/v1.1.1",
     "icon_path": "assets/incident_plugin_icon.svg",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "min_server_version": "5.28.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -17,9 +17,9 @@ const manifestStr = `
   "description": "This plugin allows users to coordinate and manage incidents within Mattermost.",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-incident-response/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-incident-response/issues",
-  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-incident-response/releases/tag/v1.1.0",
+  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-incident-response/releases/tag/v1.1.1",
   "icon_path": "assets/incident_plugin_icon.svg",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "min_server_version": "5.28.0",
   "server": {
     "executables": {

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -109,6 +109,7 @@ func incidentProperties(incdnt *incident.Incident, userID string) map[string]int
 		"TeamID":              incdnt.TeamID,
 		"CreateAt":            incdnt.CreateAt,
 		"PostID":              incdnt.PostID,
+		"PlaybookID":          incdnt.PlaybookID,
 		"NumChecklists":       len(incdnt.Checklists),
 		"TotalChecklistItems": totalChecklistItems,
 		"ActiveStage":         incdnt.ActiveStage,

--- a/server/telemetry/rudder_test.go
+++ b/server/telemetry/rudder_test.go
@@ -309,6 +309,7 @@ func TestIncidentProperties(t *testing.T) {
 		"CommanderUserID":     dummyIncident.CommanderUserID,
 		"TeamID":              dummyIncident.TeamID,
 		"CreateAt":            dummyIncident.CreateAt,
+		"PlaybookID":          dummyIncident.PlaybookID,
 		"PostID":              dummyIncident.PostID,
 		"NumChecklists":       1,
 		"TotalChecklistItems": 1,

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -7,9 +7,9 @@ const manifest = JSON.parse(`
     "description": "This plugin allows users to coordinate and manage incidents within Mattermost.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-incident-response/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-incident-response/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-incident-response/releases/tag/v1.1.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-incident-response/releases/tag/v1.1.1",
     "icon_path": "assets/incident_plugin_icon.svg",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "min_server_version": "5.28.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
- Include playbook ID, bump version

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-30207
- https://mattermost.atlassian.net/browse/MM-30208
