### PR TITLE
[MM-15772] Showing more user details in the share playbook auto-complete

### DIFF
--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('executeSlashCommand', (command) => {
     cy.findByTestId('post_textbox').clear().type(command);
 
     // Using esc to make sure we exit out of slash command autocomplete
-    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 100}).type('{enter}');
+    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 120}).type('{enter}');
 });
 
 // Opens incident dialog using the `/incident start` slash command

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('executeSlashCommand', (command) => {
     cy.findByTestId('post_textbox').clear().type(command);
 
     // Using esc to make sure we exit out of slash command autocomplete
-    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 100}).type('{enter}');
+    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 500}).type('{enter}');
 });
 
 // Opens incident dialog using the `/incident start` slash command

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('executeSlashCommand', (command) => {
     cy.findByTestId('post_textbox').clear().type(command);
 
     // Using esc to make sure we exit out of slash command autocomplete
-    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 150}).type('{enter}');
+    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 200}).type('{enter}');
 });
 
 // Opens incident dialog using the `/incident start` slash command

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('executeSlashCommand', (command) => {
     cy.findByTestId('post_textbox').clear().type(command);
 
     // Using esc to make sure we exit out of slash command autocomplete
-    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 120}).type('{enter}');
+    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 150}).type('{enter}');
 });
 
 // Opens incident dialog using the `/incident start` slash command

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('executeSlashCommand', (command) => {
     cy.findByTestId('post_textbox').clear().type(command);
 
     // Using esc to make sure we exit out of slash command autocomplete
-    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 300}).type('{enter}');
+    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 200}).type('{enter}');
 });
 
 // Opens incident dialog using the `/incident start` slash command

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('executeSlashCommand', (command) => {
     cy.findByTestId('post_textbox').clear().type(command);
 
     // Using esc to make sure we exit out of slash command autocomplete
-    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 500}).type('{enter}');
+    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 300}).type('{enter}');
 });
 
 // Opens incident dialog using the `/incident start` slash command

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('executeSlashCommand', (command) => {
     cy.findByTestId('post_textbox').clear().type(command);
 
     // Using esc to make sure we exit out of slash command autocomplete
-    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 200}).type('{enter}');
+    cy.findByTestId('post_textbox').type('{esc}{esc}{esc}{esc}', {delay: 100}).type('{enter}');
 });
 
 // Opens incident dialog using the `/incident start` slash command

--- a/webapp/src/components/backstage/profile_autocomplete.tsx
+++ b/webapp/src/components/backstage/profile_autocomplete.tsx
@@ -4,10 +4,11 @@ import {debounce} from 'debounce';
 import AsyncSelect from 'react-select/async';
 
 import styled from 'styled-components';
-import Profile from 'src/components/profile/profile';
 import {ActionFunc} from 'mattermost-redux/types/actions';
 import {UserProfile} from 'mattermost-redux/types/users';
 import {OptionsType, ControlProps} from 'react-select';
+
+import Profile from 'src/components/profile/profile';
 
 const StyledAsyncSelect = styled(AsyncSelect)`
     flex-grow: 1;
@@ -89,7 +90,7 @@ const ProfileAutocomplete: FC<Props> = (props: Props) => {
     const formatOptionLabel = (option: UserProfile) => {
         return (
             <React.Fragment>
-                <Profile userId={option.id} />
+                <Profile userId={option.id}/>
             </React.Fragment>
         );
     };

--- a/webapp/src/components/backstage/profile_autocomplete.tsx
+++ b/webapp/src/components/backstage/profile_autocomplete.tsx
@@ -4,6 +4,7 @@ import {debounce} from 'debounce';
 import AsyncSelect from 'react-select/async';
 
 import styled from 'styled-components';
+import Profile from 'src/components/profile/profile';
 import {ActionFunc} from 'mattermost-redux/types/actions';
 import {UserProfile} from 'mattermost-redux/types/users';
 import {OptionsType, ControlProps} from 'react-select';
@@ -88,7 +89,7 @@ const ProfileAutocomplete: FC<Props> = (props: Props) => {
     const formatOptionLabel = (option: UserProfile) => {
         return (
             <React.Fragment>
-                { `@${option.username}`}
+                <Profile userId={option.id} />
             </React.Fragment>
         );
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

### Summary
This adds more info to the auto-complete dropdown. I found that the profile component has exactly what we need.

**Where to find the change:**
1. Click Create a Playbook
2. On the RHS type in a name

**Expected Result:** We see the profile picture and name (display configuration dependent) in the dropdown suggestions

### Ticket Link
 https://github.com/mattermost/mattermost-server/issues/15772


