### PR TITLE
MM-30249: Avoid sending internal errors to the client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -40,14 +40,13 @@ type Client struct {
 // ErrorResponse reports an error caused by an API request.
 type ErrorResponse struct {
 	Response *http.Response // HTTP response that caused this error
-	Message  string         `json:"message"` // error message
-	Details  string         `json:"details"` // more detail on the error
+	Error    string         `json:"error"` // error message
 }
 
 func (r *ErrorResponse) Error() string {
-	return fmt.Sprintf("%v %v: %d %v %+v",
+	return fmt.Sprintf("%v %v: %d %v",
 		r.Response.Request.Method, r.Response.Request.URL,
-		r.Response.StatusCode, r.Message, r.Details)
+		r.Response.StatusCode, r.Error)
 }
 
 // ListOptions specifies the optional parameters to various List methods that

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -56,27 +56,36 @@ func ReturnJSON(w http.ResponseWriter, pointerToObject interface{}, httpStatus i
 	}
 }
 
-// HandleError writes err as json into the response.
-func HandleError(w http.ResponseWriter, err error) {
-	HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", err)
+// HandleError logs the internal error and sends a generic error as JSON in a 500 response.
+func HandleError(w http.ResponseWriter, internalErr error) {
+	HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", internalErr)
 }
 
-// HandleErrorWithCode writes code, errMsg and errDetails as json into the response.
-func HandleErrorWithCode(w http.ResponseWriter, code int, errMsg string, errDetails error) {
+// HandleErrorWithCode logs the internal error and sends the public facing error
+// message as JSON in a response with the provided code.
+func HandleErrorWithCode(w http.ResponseWriter, code int, publicErrorMsg string, internalErr error) {
 	w.WriteHeader(code)
+
 	details := ""
-	if errDetails != nil {
-		details = errDetails.Error()
+	if internalErr != nil {
+		details = internalErr.Error()
 	}
-	b, _ := json.Marshal(struct {
-		Message string `json:"message"` // A human-readable message providing details about the error.
-		Details string `json:"details"` // More details about the error.
+
+	loggedMsg, _ := json.Marshal(struct {
+		Message string `json:"message"` // A public facing message providing details about the error.
+		Details string `json:"details"` // More details, potentially sensitive, about the error.
 	}{
-		Message: errMsg,
+		Message: publicErrorMsg,
 		Details: details,
 	})
-	logrus.Warn(string(b))
-	_, _ = w.Write(b)
+	logrus.Warn(string(loggedMsg))
+
+	responseMsg, _ := json.Marshal(struct {
+		Error string `json:"error"` // A public facing message providing details about the error.
+	}{
+		Error: publicErrorMsg,
+	})
+	_, _ = w.Write(responseMsg)
 }
 
 // MattermostAuthorizationRequired checks if request is authorized.

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -334,10 +334,10 @@ func TestIncidents(t *testing.T) {
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
-		var res struct{ Message string }
+		var res struct{ Error string }
 		err = json.NewDecoder(resp.Body).Decode(&res)
 		assert.NoError(t, err)
-		assert.Equal(t, "interactive dialog's userID must be the same as the requester's userID", res.Message)
+		assert.Equal(t, "interactive dialog's userID must be the same as the requester's userID", res.Error)
 	})
 
 	t.Run("create valid incident with missing playbookID from dialog", func(t *testing.T) {

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -175,7 +175,7 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 	userID := r.Header.Get("Mattermost-User-ID")
 	opts, err := parseGetPlaybooksOptions(r.URL)
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to get playbooks", err)
+		HandleErrorWithCode(w, http.StatusBadRequest, fmt.Sprintf("failed to get playbooks: %s", err.Error()), nil)
 		return
 	}
 

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -818,13 +818,12 @@ func TestSortingPlaybooks(t *testing.T) {
 				assert.NoError(t, err)
 
 				errorResult := struct {
-					Message string `json:"message"`
-					Details string `json:"details"`
+					Error string `json:"error"`
 				}{}
 
 				err = json.Unmarshal(result, &errorResult)
 				require.NoError(t, err)
-				assert.Contains(t, errorResult.Details, data.expectedErr.Error())
+				assert.Contains(t, errorResult.Error, data.expectedErr.Error())
 			}
 		})
 	}
@@ -1040,13 +1039,12 @@ func TestPagingPlaybooks(t *testing.T) {
 				assert.NoError(t, err)
 
 				errorResult := struct {
-					Message string `json:"message"`
-					Details string `json:"details"`
+					Error string `json:"error"`
 				}{}
 
 				err = json.Unmarshal(result, &errorResult)
 				require.NoError(t, err)
-				assert.Contains(t, errorResult.Details, data.expectedErr.Error())
+				assert.Contains(t, errorResult.Error, data.expectedErr.Error())
 			}
 		})
 	}


### PR DESCRIPTION
#### Summary

Changed `HandleErrorWithCode` to only log the internal error, while it sends the public message to the client. I renamed the parameters in the function to make the distinction between both arguments clearer.

I also needed to change a couple of tests that were expecting the error where it no longer is. I reviewed all the places that were using this function and all of them look to be using it correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30249
