### PR TITLE
MM-30191: handle leaving channel without teamId

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -148,9 +148,8 @@ export const receivedTeamIncidents = (incidents: Incident[]): ReceivedTeamIncide
     incidents,
 });
 
-export const removedFromIncidentChannel = (teamId: string, channelId: string): RemovedFromIncidentChannel => ({
+export const removedFromIncidentChannel = (channelId: string): RemovedFromIncidentChannel => ({
     type: REMOVED_FROM_INCIDENT_CHANNEL,
-    teamId,
     channelId,
 });
 

--- a/webapp/src/reducer.test.ts
+++ b/webapp/src/reducer.test.ts
@@ -1,0 +1,64 @@
+import {
+    REMOVED_FROM_INCIDENT_CHANNEL,
+} from 'src/types/actions';
+import reducer from 'src/reducer';
+
+describe('myIncidentsByTeam', () => {
+    // @ts-ignore
+    const initialState = reducer(undefined, {}); // eslint-disable-line no-undefined
+
+    describe('REMOVED_FROM_INCIDENT_CHANNEL', () => {
+        const makeState = (myIncidentsByTeam: any) => ({
+            ...initialState,
+            myIncidentsByTeam,
+        });
+
+        it('should ignore a channel not in the data structure', () => {
+            const state = makeState({
+                teamId1: {
+                    channelId1: {id: 'incidentId1'},
+                    channelId2: {id: 'incidentId2'},
+                },
+                teamId2: {
+                    channelId3: {id: 'incidentId3'},
+                    channelId4: {id: 'incidentId4'},
+                },
+            });
+            const action = {
+                type: REMOVED_FROM_INCIDENT_CHANNEL,
+                channelId: 'unknown',
+            };
+            const expectedState = state;
+
+            expect(reducer(state, action)).toStrictEqual(expectedState);
+        });
+
+        it('should remove a channel in the data structure', () => {
+            const state = makeState({
+                teamId1: {
+                    channelId1: {id: 'incidentId1'},
+                    channelId2: {id: 'incidentId2'},
+                },
+                teamId2: {
+                    channelId3: {id: 'incidentId3'},
+                    channelId4: {id: 'incidentId4'},
+                },
+            });
+            const action = {
+                type: REMOVED_FROM_INCIDENT_CHANNEL,
+                channelId: 'channelId2',
+            };
+            const expectedState = makeState({
+                teamId1: {
+                    channelId1: {id: 'incidentId1'},
+                },
+                teamId2: {
+                    channelId3: {id: 'incidentId3'},
+                    channelId4: {id: 'incidentId4'},
+                },
+            });
+
+            expect(reducer(state, action)).toEqual(expectedState);
+        });
+    });
+});

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -114,12 +114,17 @@ const myIncidentsByTeam = (state: Record<string, Record<string, Incident>> = {},
     }
     case REMOVED_FROM_INCIDENT_CHANNEL: {
         const removedFromChannelAction = action as RemovedFromIncidentChannel;
-        const teamId = removedFromChannelAction.teamId;
+        const channelId = removedFromChannelAction.channelId;
+        const teamId = Object.keys(state).find((t) => Boolean(state[t][channelId]));
+        if (!teamId) {
+            return state;
+        }
+
         const newState = {
             ...state,
             [teamId]: {...state[teamId]},
         };
-        delete newState[teamId][removedFromChannelAction.channelId];
+        delete newState[teamId][channelId];
         return newState;
     }
     default:

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -54,7 +54,6 @@ export interface ReceivedTeamIncidents {
 
 export interface RemovedFromIncidentChannel {
     type: typeof REMOVED_FROM_INCIDENT_CHANNEL;
-    teamId: string;
     channelId: string;
 }
 

--- a/webapp/src/websocket_events.ts
+++ b/webapp/src/websocket_events.ts
@@ -7,7 +7,6 @@ import {GetStateFunc} from 'mattermost-redux/types/actions';
 import {WebSocketMessage} from 'mattermost-redux/actions/websocket';
 import {getCurrentTeam, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {navigateToUrl} from 'src/browser_routing';
 import {
@@ -97,8 +96,7 @@ export function handleWebsocketUserRemoved(getState: GetStateFunc, dispatch: Dis
     return (msg: WebSocketMessage) => {
         const currentUserId = getCurrentUserId(getState());
         if (currentUserId === msg.broadcast.user_id) {
-            const channel = getChannel(getState(), msg.data.channel_id);
-            dispatch(removedFromIncidentChannel(channel.team_id, channel.id));
+            dispatch(removedFromIncidentChannel(msg.data.channel_id));
         }
     };
 }


### PR DESCRIPTION
#### Summary
When we leave a channel, the websocket event doesn't include the channel metadata: we only know the channel id. Avoid trying to reference a null `channel` object and instead rely solely on the `channelId` in the event.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-30191