### PR TITLE
MM-30787 - Deleting a status post should update Last Updated field

### DIFF
--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -1158,7 +1158,7 @@ func addRandomBits(name string) string {
 func findNewestNonDeletedPostID(posts []StatusPost) string {
 	var newest *StatusPost
 	for i, p := range posts {
-		if newest == nil || p.DeleteAt == 0 && p.CreateAt > newest.CreateAt {
+		if p.DeleteAt == 0 && (newest == nil || p.CreateAt > newest.CreateAt) {
 			newest = &posts[i]
 		}
 	}

--- a/tests-e2e/.eslintrc
+++ b/tests-e2e/.eslintrc
@@ -15,6 +15,10 @@
   "rules": {
     "import/no-unresolved": 2,
     "comma-dangle": 0,
+    "dot-location": [
+      2,
+      "property"
+    ],
     "import/order": [
       "error",
       {

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -1299,7 +1299,7 @@ describe('rhs incident list', () => {
 
                 cy.findByText(incidentName).should('exist');
 
-                // * Verify the last updated is blank
+                // * Verify the last updated is updated
                 cy.findByText('Last updated:').should('exist');
                 cy.findByText('Last updated:').next().should('have.text', '< 1m ago');
             });

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -1377,7 +1377,7 @@ describe('rhs incident list', () => {
 
                             cy.findByText(incidentName).should('exist');
 
-                            // * Verify the last updated is blank
+                            // * Verify the last updated is updated
                             cy.findByText('Last updated:').should('exist');
                             cy.findByText('Last updated:').next().should('have.text', '< 1m ago');
                         });

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -626,7 +626,9 @@ describe('rhs incident list', () => {
                 cy.get('[class^=IncidentContainer]').eq(0).within(() => {
                     cy.findByText(secondIncidentName).should('exist');
                 });
-                cy.get('[class^=IncidentContainer]').eq(0).should('have.css', 'box-shadow', 'rgba(61, 60, 64, 0.24) 0px -1px 0px 0px inset');
+                cy.get('[class^=IncidentContainer]')
+                    .eq(0)
+                    .should('have.css', 'box-shadow', 'rgba(61, 60, 64, 0.24) 0px -1px 0px 0px inset');
             });
 
             // * Verify first incident is highlighted
@@ -634,7 +636,9 @@ describe('rhs incident list', () => {
                 cy.get('[class^=IncidentContainer]').eq(1).within(() => {
                     cy.findByText(incidentName).should('exist');
                 });
-                cy.get('[class^=IncidentContainer]').eq(1).should('have.css', 'box-shadow', 'rgba(61, 60, 64, 0.24) 0px -1px 0px 0px inset, rgb(22, 109, 224) 4px 0px 0px 0px inset');
+                cy.get('[class^=IncidentContainer]')
+                    .eq(1)
+                    .should('have.css', 'box-shadow', 'rgba(61, 60, 64, 0.24) 0px -1px 0px 0px inset, rgb(22, 109, 224) 4px 0px 0px 0px inset');
             });
         });
 
@@ -1231,6 +1235,154 @@ describe('rhs incident list', () => {
 
             // * Verify we reached the playbook backstage
             cy.url().should('include', '/ad-1/com.mattermost.plugin-incident-management/incidents');
+        });
+    });
+
+    describe('Last updated', () => {
+        it('should update when in incident channel', () => {
+            // # delete all incidents
+            cy.endAllActiveIncidents(teamId);
+
+            // # Login as user-1
+            cy.apiLogin('user-1');
+
+            cy.apiGetCurrentUser().then((user) => {
+                expect(user.id).to.equal(userId);
+            });
+
+            // # Navigate directly to a non-incident channel
+            cy.wait(1000).visit('/ad-1/channels/town-square');
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # start new incident
+            const now = Date.now();
+            const incidentName = 'Incident (' + now + ')';
+            const incidentChannelName = 'incident-' + now;
+            cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
+            cy.verifyIncidentActive(teamId, incidentName);
+
+            // # Open the incident channel from the LHS.
+            cy.get(`#sidebarItem_${incidentChannelName}`).click();
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // * Verify the incident RHS is open.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByTestId('rhs-title').should('exist').within(() => {
+                    cy.findByText(incidentName).should('exist');
+                });
+
+                // # Click the back button
+                cy.findByTestId('back-button').should('exist').click();
+            });
+
+            // * Verify the rhs list is open and we can see the new incident
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                cy.findByText(incidentName).should('exist');
+
+                // * Verify the last updated is blank
+                cy.findByText('Last updated:').should('exist');
+                cy.findByText('Last updated:').next().should('have.text', '-');
+            });
+
+            // # Update the status
+            cy.updateStatus('Status update 1');
+
+            // * verify the last updated time is updated
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                cy.findByText(incidentName).should('exist');
+
+                // * Verify the last updated is blank
+                cy.findByText('Last updated:').should('exist');
+                cy.findByText('Last updated:').next().should('have.text', '< 1m ago');
+            });
+        });
+
+        it('should update when in another incident channel', () => {
+            // # delete all incidents
+            cy.endAllActiveIncidents(teamId);
+
+            // # Login as user-1
+            cy.apiLogin('user-1');
+
+            cy.apiGetCurrentUser().then((user) => {
+                expect(user.id).to.equal(userId);
+            });
+
+            // # Navigate directly to a non-incident channel
+            cy.wait(1000).visit('/ad-1/channels/town-square');
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # start new incident
+            const now = Date.now();
+            const incidentName = 'Incident (' + now + ')';
+            const incidentChannelName = 'incident-' + now;
+            cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId})
+                .then((incident) => {
+                    const incidentId = incident.id;
+
+                    cy.verifyIncidentActive(teamId, incidentName);
+
+                    // # Open the incident channel from the LHS.
+                    cy.get(`#sidebarItem_${incidentChannelName}`).click();
+
+                    // # Ensure the channel is loaded before continuing (allows redux to sync).
+                    cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+                    // * Verify the incident RHS is open.
+                    cy.get('#rhsContainer').should('exist').within(() => {
+                        cy.findByTestId('rhs-title').should('exist').within(() => {
+                            cy.findByText(incidentName).should('exist');
+                        });
+
+                        // # Click the back button
+                        cy.findByTestId('back-button').should('exist').click();
+                    });
+
+                    // * Verify the rhs list is open and we can see the new incident
+                    cy.get('#rhsContainer').should('exist').within(() => {
+                        cy.findByText('Your Ongoing Incidents').should('exist');
+
+                        cy.findByText(incidentName).should('exist');
+
+                        // * Verify the last updated is blank
+                        cy.findByText('Last updated:').should('exist');
+                        cy.findByText('Last updated:').next().should('have.text', '-');
+                    });
+
+                    // # Update the status
+                    cy.apiGetChannelByName('ad-1', incidentChannelName).then(({channel}) => {
+                        const channelId = channel.id;
+
+                        cy.apiUpdateStatus({
+                            incidentId,
+                            userId,
+                            channelId,
+                            teamId,
+                            message: 'Status update 2',
+                        });
+
+                        // * verify the last updated time is updated
+                        cy.get('#rhsContainer').should('exist').within(() => {
+                            cy.findByText('Your Ongoing Incidents').should('exist');
+
+                            cy.findByText(incidentName).should('exist');
+
+                            // * Verify the last updated is blank
+                            cy.findByText('Last updated:').should('exist');
+                            cy.findByText('Last updated:').next().should('have.text', '< 1m ago');
+                        });
+                    });
+                });
         });
     });
 });

--- a/tests-e2e/cypress/support/plugin_api_commands.js
+++ b/tests-e2e/cypress/support/plugin_api_commands.js
@@ -6,8 +6,8 @@ import endpoints from './endpoints.json';
 const incidentsEndpoint = endpoints.incidents;
 
 /**
-* Get all incidents directly via API
-*/
+ * Get all incidents directly via API
+ */
 Cypress.Commands.add('apiGetAllIncidents', (teamId) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -21,8 +21,8 @@ Cypress.Commands.add('apiGetAllIncidents', (teamId) => {
 });
 
 /**
-* Get all active incidents directly via API
-*/
+ * Get all active incidents directly via API
+ */
 Cypress.Commands.add('apiGetAllActiveIncidents', (teamId) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -36,8 +36,8 @@ Cypress.Commands.add('apiGetAllActiveIncidents', (teamId) => {
 });
 
 /**
-* Get incident by name directly via API
-*/
+ * Get incident by name directly via API
+ */
 Cypress.Commands.add('apiGetIncidentByName', (teamId, name) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -51,10 +51,10 @@ Cypress.Commands.add('apiGetIncidentByName', (teamId, name) => {
 });
 
 /**
-* Get an incident directly via API
-* @param {String} incidentId
-* All parameters required
-*/
+ * Get an incident directly via API
+ * @param {String} incidentId
+ * All parameters required
+ */
 Cypress.Commands.add('apiGetIncident', (incidentId) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -218,3 +218,25 @@ Cypress.Commands.add('verifyPlaybookCreated', (teamId, playbookTitle) => (
         assert.isDefined(playbook);
     })
 ));
+
+// Update an incident's status programmatically.
+Cypress.Commands.add('apiUpdateStatus', ({incidentId, userId, channelId, teamId, message}) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: `${incidentsEndpoint}/${incidentId}/update-status-dialog`,
+        method: 'POST',
+        body: {
+            type: 'dialog_submission',
+            callback_id: '',
+            state: '',
+            user_id: userId,
+            channel_id: channelId,
+            team_id: teamId,
+            submission: {message, reminder: '15'},
+            cancelled: false,
+        },
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap(response.body);
+    });
+});

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -66,8 +66,7 @@ export default class Plugin {
         // Would rather use a saga and listen for ActionTypes.UPDATE_MOBILE_VIEW.
         window.addEventListener('resize', debounce(updateMainMenuAction, 300));
 
-        const {toggleRHSPlugin} = registry.registerRightHandSidebarComponent(RightHandSidebar,
-            <RHSTitle/>);
+        const {toggleRHSPlugin} = registry.registerRightHandSidebarComponent(RightHandSidebar, <RHSTitle/>);
         const boundToggleRHSAction = (): void => store.dispatch(toggleRHSPlugin);
 
         // Store the toggleRHS action to use later

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -34,8 +34,7 @@ import {
     handleWebsocketIncidentCreated,
     handleWebsocketUserAdded,
     handleWebsocketUserRemoved,
-    handleWebsocketPostDeleted,
-    handleWebsocketPostEdited,
+    handleWebsocketPostEditedOrDeleted,
 } from './websocket_events';
 import {
     WEBSOCKET_INCIDENT_UPDATED,
@@ -67,7 +66,8 @@ export default class Plugin {
         // Would rather use a saga and listen for ActionTypes.UPDATE_MOBILE_VIEW.
         window.addEventListener('resize', debounce(updateMainMenuAction, 300));
 
-        const {toggleRHSPlugin} = registry.registerRightHandSidebarComponent(RightHandSidebar, <RHSTitle/>);
+        const {toggleRHSPlugin} = registry.registerRightHandSidebarComponent(RightHandSidebar,
+            <RHSTitle/>);
         const boundToggleRHSAction = (): void => store.dispatch(toggleRHSPlugin);
 
         // Store the toggleRHS action to use later
@@ -81,8 +81,8 @@ export default class Plugin {
         registry.registerWebSocketEventHandler(WEBSOCKET_INCIDENT_CREATED, handleWebsocketIncidentCreated(store.getState, store.dispatch));
         registry.registerWebSocketEventHandler(WebsocketEvents.USER_ADDED, handleWebsocketUserAdded(store.getState, store.dispatch));
         registry.registerWebSocketEventHandler(WebsocketEvents.USER_REMOVED, handleWebsocketUserRemoved(store.getState, store.dispatch));
-        registry.registerWebSocketEventHandler(WebsocketEvents.POST_DELETED, handleWebsocketPostDeleted(store.getState, store.dispatch));
-        registry.registerWebSocketEventHandler(WebsocketEvents.POST_EDITED, handleWebsocketPostEdited(store.getState, store.dispatch));
+        registry.registerWebSocketEventHandler(WebsocketEvents.POST_DELETED, handleWebsocketPostEditedOrDeleted(store.getState, store.dispatch));
+        registry.registerWebSocketEventHandler(WebsocketEvents.POST_EDITED, handleWebsocketPostEditedOrDeleted(store.getState, store.dispatch));
 
         // Listen for channel changes and open the RHS when appropriate.
         store.subscribe(makeRHSOpener(store));

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -52,6 +52,11 @@ export const myActiveIncidentsList = createSelector(
     },
 );
 
+// myActiveIncidentsMap returns a map indexed by channelId->incident for the current team
+export const myIncidentsMap = (state: GlobalState) => {
+    return myIncidentsByTeam(state)[getCurrentTeamId(state)] || {};
+};
+
 export const isExportLicensed = (state: GlobalState): boolean => {
     const license = getLicense(state);
 


### PR DESCRIPTION
#### Summary
- Now we're updating the incident list for every status post, even if we're currently not in that incident channel
- That kicks the incident list, which updates `Last updated` field in the RHS list
- This is one more step towards keeping a synced model of the incidents on the client side

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-30787