### PR TITLE
Playbook link is broken

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Mattermost Incident Management allows your team to coordinate, manage, and resol
 Incidents are situations which require an immediate response and benefit from a clearly defined process guiding towards resolution. Incident Management allows your team to coordinate, manage, and resolve incidents from within Mattermost. You can:
 
 - Automatically create a new channel that can be organized in the left-hand sidebar using custom categories.
-- Use [playbooks](/playbooks/creating-and-managing-playbooks.md) to perform automated actions such as create a Jira ticket, start a Zoom call, or find out who is on-call in Opsgenie.
+- Use [playbooks](/end-users-guide/creating-and-managing-playbooks.md) to perform automated actions such as create a Jira ticket, start a Zoom call, or find out who is on-call in Opsgenie.
 - Iterate on and refine processes after each incident.
 
 When incidents are monitored, coordinated, and measured effectively, you can add transparency, maximize effectiveness, and save costs by cutting down time taken to respond to and resolve incidents.


### PR DESCRIPTION
Replace existing link with this: https://mattermost.gitbook.io/mattermost-incident-management/end-users-guide/creating-and-managing-playbooks (or relative link equivalent).
