### PR TITLE
MM-30259: Fix backstage bug

### DIFF
--- a/tests-e2e/cypress/integration/backstage/incident_list_spec.js
+++ b/tests-e2e/cypress/integration/backstage/incident_list_spec.js
@@ -56,6 +56,23 @@ describe('backstage incident list', () => {
         cy.get('#root').findByText('What are Incidents?').should('be.visible');
     });
 
+    it('New incident works when the backstage is the first page loaded', () => {
+        // # Navigate to the incidents backstage of a team with no incidents.
+        cy.visit('/reiciendis-0/com.mattermost.plugin-incident-management/incidents');
+
+        // # Make sure that the Redux store is empty
+        cy.reload();
+
+        // # Click on New Incident button
+        cy.findByText('New Incident').click();
+
+        // * Verify that we are in the centre channel view, out of the backstage
+        cy.url().should('include', '/reiciendis-0/channels');
+
+        // * Verify that the interactive dialog modal to create an incident is visible
+        cy.get('#interactiveDialogModal').should('exist');
+    });
+
     it('has "Incidents" and team name in heading', () => {
         // # Start the incident
         const now = Date.now();

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -89,8 +89,13 @@ export function fetchIncidentChannels(teamID: string, userID: string) {
 }
 
 export async function clientExecuteCommand(dispatch: Dispatch<AnyAction>, getState: GetStateFunc, command: string) {
-    const currentChannel = getCurrentChannel(getState());
+    let currentChannel = getCurrentChannel(getState());
     const currentTeamId = getCurrentTeamId(getState());
+
+    // Default to town square if there is no current channel (i.e., if Mattermost has not yet loaded)
+    if (!currentChannel) {
+        currentChannel = await Client4.getChannelByName(currentTeamId, 'town-square');
+    }
 
     const args = {
         channel_id: currentChannel?.id,


### PR DESCRIPTION
#### Summary
Calling `clientExecuteCommand` relies on the Redux store containing a current channel. If the first URL to be loaded is the one in the backstage, such channel does not exist. The proposed fix is simple: just defaulting to town-square when no current channel exists. I think this is a good solution, but I'm open to any other ideas you have (the best solution would be not to have a mandatory channel in the API endpoint, of course, but that would be a weeks long solution, probably).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30259
