### PR TITLE
Change the text of the ephemeral message from "You can only show..." to "You can only see..."

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -278,7 +278,7 @@ func (r *Runner) actionCommander(args []string) {
 func (r *Runner) actionShowCommander([]string) {
 	incidentID, err := r.incidentService.GetIncidentIDForChannel(r.args.ChannelId)
 	if errors.Is(err, incident.ErrNotFound) {
-		r.postCommandResponse("You can only show the commander from within the incident's channel.")
+		r.postCommandResponse("You can only see the commander from within the incident's channel.")
 		return
 	} else if err != nil {
 		r.warnUserAndLogErrorf("Error retrieving incident for channel %s: %v", r.args.ChannelId, err)

--- a/tests-e2e/cypress/integration/frontstage/slash_command/commander_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/slash_command/commander_spec.js
@@ -87,7 +87,7 @@ describe('slash command > commander', () => {
             cy.executeSlashCommand('/incident commander');
 
             // * Verify the expected error message.
-            cy.verifyEphemeralMessage('You can only show the commander from within the incident\'s channel.');
+            cy.verifyEphemeralMessage('You can only see the commander from within the incident\'s channel.');
         });
 
         it('should show the current commander', () => {


### PR DESCRIPTION
#### Summary
Change the text of the ephemeral message from "You can only show..." to "You can only see..." in command.go

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/16423
