### PR TITLE
MM-31187 Enable broadcast to private channels.

### DIFF
--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -60,6 +60,16 @@ func (h *PlaybookHandler) createPlaybook(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if pbook.BroadcastChannelID != "" &&
+		!h.pluginAPI.User.HasPermissionToChannel(userID, pbook.BroadcastChannelID, model.PERMISSION_CREATE_POST) {
+		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
+			"userID %s does not have permission to create posts in the channel %s",
+			userID,
+			pbook.BroadcastChannelID,
+		))
+		return
+	}
+
 	if !permissions.CanViewTeam(userID, pbook.TeamID, h.pluginAPI) {
 		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
 			"userID %s does not have permission to create playbook on teamID %s",
@@ -129,6 +139,17 @@ func (h *PlaybookHandler) updatePlaybook(w http.ResponseWriter, r *http.Request)
 			"userID %s does not have permission to update playbook on teamID %s",
 			userID,
 			oldPlaybook.TeamID,
+		))
+		return
+	}
+
+	if pbook.BroadcastChannelID != "" &&
+		pbook.BroadcastChannelID != oldPlaybook.BroadcastChannelID &&
+		!h.pluginAPI.User.HasPermissionToChannel(userID, pbook.BroadcastChannelID, model.PERMISSION_CREATE_POST) {
+		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
+			"userID %s does not have permission to create posts in the channel %s",
+			userID,
+			pbook.BroadcastChannelID,
 		))
 		return
 	}

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -12999,15 +12999,15 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/mattermost-redux/-/mattermost-redux-5.24.2.tgz",
-      "integrity": "sha512-0dYmUePc+JIAdumifKPCh4S/T4OdqK08vHVMI4adLRTXz0wVr2IXpuDVCwHHNPMkt5H+eSD61eE6aqs1cG4whA==",
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/mattermost-redux/-/mattermost-redux-5.28.1.tgz",
+      "integrity": "sha512-W+HEHY5SsKbr0gdPuhcjAHt3UQRoOINzDeMHly2MTONgjzfquddkd/ZwTFiuslfuzzK+Y08n4By3x3PV+5XHkQ==",
       "requires": {
-        "core-js": "3.6.4",
+        "core-js": "3.6.5",
         "form-data": "3.0.0",
         "gfycat-sdk": "1.4.18",
         "isomorphic-fetch": "2.2.1",
-        "moment-timezone": "0.5.28",
+        "moment-timezone": "0.5.31",
         "redux": "4.0.5",
         "redux-action-buffer": "1.2.0",
         "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
@@ -13016,15 +13016,11 @@
         "redux-thunk": "2.3.0",
         "remote-redux-devtools": "0.5.16",
         "reselect": "4.0.0",
+        "rudder-sdk-js": "1.0.6",
         "serialize-error": "6.0.0",
         "shallow-equals": "1.0.0"
       },
       "dependencies": {
-        "core-js": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
-        },
         "form-data": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -13033,14 +13029,6 @@
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
-          }
-        },
-        "moment-timezone": {
-          "version": "0.5.28",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-          "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
-          "requires": {
-            "moment": ">= 2.9.0"
           }
         },
         "redux-persist": {
@@ -13053,18 +13041,10 @@
             "lodash-es": "^4.17.4"
           }
         },
-        "serialize-error": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-6.0.0.tgz",
-          "integrity": "sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==",
-          "requires": {
-            "type-fest": "^0.12.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
-          "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg=="
+        "rudder-sdk-js": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-1.0.6.tgz",
+          "integrity": "sha512-My/yfplEbfYXUbs3nH7d/s931tl3GNF3G6NNyOdhY5aLlPGBL+sqSUKI/vQZaJzjb1sfCF6ZpM1IBUUtX2yeVA=="
         }
       }
     },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -85,7 +85,7 @@
     "chart.js": "2.9.3",
     "core-js": "3.6.5",
     "debounce": "^1.2.0",
-    "mattermost-redux": "5.24.2",
+    "mattermost-redux": "5.28.1",
     "mattermost-webapp": "github:mattermost/mattermost-webapp#0b27dbfaa79b88cc207d835bbe604577d9397425",
     "moment": "2.26.0",
     "qs": "6.9.4",

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -1,10 +1,9 @@
 import React, {FC} from 'react';
 import {OptionsType} from 'react-select';
-import {useDispatch, useSelector} from 'react-redux';
+import {useSelector} from 'react-redux';
+import {getMyChannels, getChannel} from 'mattermost-redux/selectors/entities/channels';
 
-import {ActionFunc} from 'mattermost-redux/types/actions';
 import {Channel} from 'mattermost-redux/types/channels';
-import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {GlobalState} from 'mattermost-redux/types/store';
 
 import {Playbook} from 'src/types/playbook';
@@ -12,15 +11,16 @@ import {Playbook} from 'src/types/playbook';
 import {StyledAsyncSelect} from './styles';
 
 export interface Props {
-    searchChannels: (term: string) => ActionFunc;
     onChannelSelected: (channelID: string | null) => void;
     playbook: Playbook;
     isClearable?: boolean;
 }
 
 const ChannelSelector: FC<Props> = (props: Props) => {
+    const selectableChannels = useSelector(getMyChannels);
+
     type GetChannelType = (channelID: string) => Channel
-    const getChannelFromID = useSelector<GlobalState, GetChannelType>((state) => (channelID) => getChannel(state, channelID));
+    const getChannelFromID = useSelector<GlobalState, GetChannelType>((state) => (channelID) => getChannel(state, channelID) || {display_name: 'Unknown Channel', id: channelID});
 
     const onChange = (channel: Channel | null) => {
         props.onChannelSelected(channel ? channel.id : null);
@@ -39,8 +39,7 @@ const ChannelSelector: FC<Props> = (props: Props) => {
     };
 
     const channelsLoader = (term: string, callback: (options: OptionsType<Channel>) => void) => {
-        // @ts-ignore
-        props.searchChannels(term.trim()).then(({data} : {data: Channel[]}) => callback(data));
+        callback(selectableChannels);
     };
 
     return (

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -7,7 +7,6 @@ import {useSelector, useDispatch} from 'react-redux';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getProfilesInTeam, searchProfiles} from 'mattermost-redux/actions/users';
-import {searchChannels as searchChannelsInTeam} from 'mattermost-redux/actions/channels';
 
 import {Team} from 'mattermost-redux/types/teams';
 
@@ -311,10 +310,6 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
         return dispatch(getProfilesInTeam(props.currentTeam.id, 0));
     };
 
-    const searchChannels = (term: string) => {
-        return dispatch(searchChannelsInTeam(props.currentTeam.id, term));
-    };
-
     const handleBroadcastInput = (channelId: string | null) => {
         setPlaybook({
             ...playbook,
@@ -399,7 +394,6 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
                                         </BackstageSubheaderDescription>
                                     </BackstageSubheaderText>
                                     <ChannelSelector
-                                        searchChannels={searchChannels}
                                         onChannelSelected={handleBroadcastInput}
                                         playbook={playbook}
                                         isClearable={true}

--- a/webapp/src/websocket_events.ts
+++ b/webapp/src/websocket_events.ts
@@ -5,7 +5,7 @@ import {Dispatch} from 'redux';
 
 import {GetStateFunc} from 'mattermost-redux/types/actions';
 import {Post} from 'mattermost-redux/types/posts';
-import {WebSocketMessage} from 'mattermost-redux/actions/websocket';
+import {WebSocketMessage} from 'mattermost-redux/types/websocket';
 import {getCurrentTeam, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
@@ -34,7 +34,7 @@ export function handleReconnect(getState: GetStateFunc, dispatch: Dispatch) {
 }
 
 export function handleWebsocketIncidentUpdated(getState: GetStateFunc, dispatch: Dispatch) {
-    return (msg: WebSocketMessage): void => {
+    return (msg: WebSocketMessage<{payload: string}>): void => {
         if (!msg.data.payload) {
             return;
         }
@@ -56,7 +56,7 @@ export function handleWebsocketIncidentUpdated(getState: GetStateFunc, dispatch:
 }
 
 export function handleWebsocketIncidentCreated(getState: GetStateFunc, dispatch: Dispatch) {
-    return (msg: WebSocketMessage): void => {
+    return (msg: WebSocketMessage<{payload:string}>): void => {
         if (!msg.data.payload) {
             return;
         }
@@ -87,7 +87,7 @@ export function handleWebsocketIncidentCreated(getState: GetStateFunc, dispatch:
 }
 
 export function handleWebsocketUserAdded(getState: GetStateFunc, dispatch: Dispatch) {
-    return async (msg: WebSocketMessage) => {
+    return async (msg: WebSocketMessage<{team_id: string, user_id: string}>) => {
         const currentUserId = getCurrentUserId(getState());
         const currentTeamId = getCurrentTeamId(getState());
         if (currentUserId === msg.data.user_id && currentTeamId === msg.data.team_id) {
@@ -98,7 +98,7 @@ export function handleWebsocketUserAdded(getState: GetStateFunc, dispatch: Dispa
 }
 
 export function handleWebsocketUserRemoved(getState: GetStateFunc, dispatch: Dispatch) {
-    return (msg: WebSocketMessage) => {
+    return (msg: WebSocketMessage<{channel_id: string, user_id: string}>) => {
         const currentUserId = getCurrentUserId(getState());
         if (currentUserId === msg.broadcast.user_id) {
             dispatch(removedFromIncidentChannel(msg.data.channel_id));
@@ -122,7 +122,7 @@ async function getIncidentFromStatusUpdate(post: Post): Promise<Incident | null>
 }
 
 export const handleWebsocketPostEditedOrDeleted = (getState: GetStateFunc, dispatch: Dispatch) => {
-    return async (msg: WebSocketMessage) => {
+    return async (msg: WebSocketMessage<{post: string}>) => {
         const activeIncidents = myIncidentsMap(getState());
         if (activeIncidents[msg.broadcast.channel_id]) {
             const incident = await getIncidentFromStatusUpdate(JSON.parse(msg.data.post));


### PR DESCRIPTION
#### Summary
Enables selection of private channels in the broadcast option. 

Also fixes bug where users could possibly select channels they are not a part of by guessing an ID. 

If another member of the playbook is not a member of the channel selected, they will see "Unknown Channel" in the dropdown. They will still be able to change the values of other fields, or select a channel they are a member of. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31187

