### PR TITLE
MM-31241, MM-31237: Fix update status dialog

### DIFF
--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -1066,12 +1066,17 @@ func (s *ServiceImpl) newUpdateIncidentDialog(message, broadcastChannelID string
 
 	broadcastChannel, err := s.pluginAPI.Channel.Get(broadcastChannelID)
 	if err == nil {
-		team, err := s.pluginAPI.Team.Get(broadcastChannel.TeamId)
-		if err != nil {
-			return nil, err
+		if broadcastChannel.Type == model.CHANNEL_OPEN {
+			team, err := s.pluginAPI.Team.Get(broadcastChannel.TeamId)
+			if err != nil {
+				return nil, err
+			}
+
+			introductionText += fmt.Sprintf(" This post will be broadcasted to [%s](/%s/channels/%s).", broadcastChannel.DisplayName, team.Name, broadcastChannel.Id)
+		} else {
+			introductionText += " This post will be broadcasted to a private channel."
 		}
 
-		introductionText += fmt.Sprintf(" This post will be broadcasted to [%s](/%s/channels/%s).", broadcastChannel.DisplayName, team.Name, broadcastChannel.Id)
 	}
 
 	options := []*model.PostActionOptions{

--- a/tests-e2e/cypress/integration/backstage/incident_list_spec.js
+++ b/tests-e2e/cypress/integration/backstage/incident_list_spec.js
@@ -179,9 +179,9 @@ describe('backstage incident list', () => {
         });
 
         it('by commander', () => {
-            cy.get('.profile-dropdown').
-                click().
-                find('.IncidentProfile').first().parent().click({force: true});
+            cy.get('.profile-dropdown')
+                .click()
+                .find('.IncidentProfile').first().parent().click({force: true});
 
             // # Wait for the incident list to update.
             cy.wait(TINY);

--- a/tests-e2e/cypress/support/server_api_commands.js
+++ b/tests-e2e/cypress/support/server_api_commands.js
@@ -250,6 +250,25 @@ Cypress.Commands.add('apiCreateGroup', (userIds = []) => {
 });
 
 /**
+ * Creates a direct channel directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {String} userAID - ID of the first user in the DM
+ * @param {String} userBID - ID of the second user in the DM
+ * All parameters required except purpose and header
+ */
+Cypress.Commands.add('apiCreateDM', (userAID, userBID) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/channels/direct',
+        method: 'POST',
+        body: [userAID, userBID],
+    }).then((response) => {
+        expect(response.status).to.equal(201);
+        return cy.wrap({channel: response.body});
+    });
+});
+
+/**
  * Gets current user's teams
  */
 

--- a/tests-e2e/cypress/support/ui_commands.js
+++ b/tests-e2e/cypress/support/ui_commands.js
@@ -23,8 +23,8 @@ function clickPostHeaderItem(postId, location, item) {
 Cypress.Commands.add('getLastPostId', () => {
     waitUntilPermanentPost();
 
-    cy.findAllByTestId('postView').last().should('have.attr', 'id').and('not.include', ':').
-        invoke('replace', 'post_', '');
+    cy.findAllByTestId('postView').last().should('have.attr', 'id').and('not.include', ':')
+        .invoke('replace', 'post_', '');
 });
 
 /**


### PR DESCRIPTION
#### Summary
Check that the broadcast channel is public, and add information about it to the interactive dialog only in that case. If it is a private channel, a DM or a GM, then a generic message "This message will be broadcasted to a private channel." is added instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31237
https://mattermost.atlassian.net/browse/MM-31241

