### PR TITLE
MM-31255: Bump plugin-api version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.3
 	github.com/gorilla/mux v1.7.4
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/mattermost/mattermost-plugin-api v0.0.13-0.20201118232355-3273dfddf611
+	github.com/mattermost/mattermost-plugin-api v0.0.13-0.20201210154933-631fdc447dbe
 	github.com/mattermost/mattermost-server/v5 v5.28.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/mattermost/logr v1.0.5 h1:TST38xROPguNh8o90BfDHpp1bz6HfTdFYX5Btw/oLwM
 github.com/mattermost/logr v1.0.5/go.mod h1:YzldchiJXgF789YNDFGXVoCHTQOTrCKwWft9Fwev1iI=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-plugin-api v0.0.13-0.20201118232355-3273dfddf611 h1:DqiH+SBVjKS0Cnp64M9cJ6Mc4ennkdCz9e53Lczz3Lk=
-github.com/mattermost/mattermost-plugin-api v0.0.13-0.20201118232355-3273dfddf611/go.mod h1:2P5T6ixjcDquVrhVdPZ1ASBWiilsxbdK6yYaqdKN/dI=
+github.com/mattermost/mattermost-plugin-api v0.0.13-0.20201210154933-631fdc447dbe h1:W2xmEgcHWQd5Qwe6xzGOX0yBEbXLG+yVnEjzNUBlINA=
+github.com/mattermost/mattermost-plugin-api v0.0.13-0.20201210154933-631fdc447dbe/go.mod h1:2P5T6ixjcDquVrhVdPZ1ASBWiilsxbdK6yYaqdKN/dI=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200731154015-c5c6a5ce5399 h1:Yz2Oo+ysCfNZ1lLe9MDXsB+jNXivpCEWyWgli0MOeyQ=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200731154015-c5c6a5ce5399/go.mod h1:1udHoNFxLFYZuS9g6/NkJkNQniAcQYVqVEbDPHSumE0=
 github.com/mattermost/mattermost-server/v5 v5.28.0 h1:BU0cfZ3UdSh7DhbdF1XtS0Cj0HMGSJT8B6MsUKgPjks=


### PR DESCRIPTION
#### Summary
I simply ran

```
go get github.com/mattermost/mattermost-plugin-api@631fdc447dbef8b3c06ac262d34c9ef0b8aaea4b
```

to get the latest commit from https://github.com/mattermost/mattermost-plugin-api/pull/79.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31255

