### PR TITLE
MM-31240: Set min height on backstage header

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -24,11 +24,9 @@ import PlaybookIcon from '../assets/icons/playbook_icon';
 import IncidentIcon from '../assets/icons/incident_icon';
 
 const BackstageContainer = styled.div`
-    overflow: hidden;
     background: var(--center-channel-bg);
-    display: flex;
-    flex-direction: column;
     height: 100%;
+    overflow-y: auto;
 `;
 
 export const BackstageNavbarIcon = styled.button`
@@ -37,8 +35,7 @@ export const BackstageNavbarIcon = styled.button`
     background: transparent;
     border-radius: 4px;
     font-size: 24px;
-    width: 40px;
-    height: 40px;
+    padding: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -53,9 +50,13 @@ export const BackstageNavbarIcon = styled.button`
 `;
 
 export const BackstageNavbar = styled.div`
+    position: sticky;
+    width: 100%;
+    top: 0;
+    z-index: 2;
+
     display: flex;
     align-items: center;
-    height: 80px;
     padding: 28px 31px;
     background: var(--center-channel-bg);
     color: var(--center-channel-color);
@@ -73,7 +74,7 @@ const BackstageTitlebarItem = styled(NavLink)`
         cursor: pointer;
         color: var(--center-channel-color);
         fill: var(--center-channel-color);
-        padding: 8px;
+        padding: 0 8px;
         margin-right: 39px;
         display: flex;
         align-items: center;
@@ -96,7 +97,6 @@ const BackstageBody = styled.div`
     z-index: 1;
     width: 100%;
     height: 100%;
-    overflow: auto;
     margin: 0 auto;
 `;
 

--- a/webapp/src/components/backstage/incidents/incident_details/incident_details.tsx
+++ b/webapp/src/components/backstage/incidents/incident_details/incident_details.tsx
@@ -37,7 +37,7 @@ const OuterContainer = styled.div`
     background: var(center-channel-bg);
     display: flex;
     flex-direction: column;
-    height: 100%;
+    min-height: 100vh;
 `;
 
 const Container = styled.div`
@@ -46,7 +46,7 @@ const Container = styled.div`
 `;
 
 const IncidentTitle = styled.div`
-    padding: 15px;
+    padding: 0 15px;
     font-size: 20px;
     line-height: 28px;
     color: var(--center-channel-color);

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -89,7 +89,7 @@ const EditableTexts = styled.div`
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    padding: 15px;
+    padding: 0 15px;
 `;
 
 const EditableTitleContainer = styled.div`
@@ -131,7 +131,7 @@ const OuterContainer = styled.div`
     background: var(center-channel-bg);
     display: flex;
     flex-direction: column;
-    height: 100%;
+    min-height: 100vh;
 `;
 
 interface Props {

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -51,6 +51,7 @@ const EditView = styled.div`
 
 const TabsHeader = styled.div`
     height: 72px;
+    min-height: 72px;
     display: flex;
     padding: 0 32px;
     border-bottom: 1px solid var(--center-channel-color-16);

--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -27,6 +27,7 @@ export const BackstageSubheader = styled.div`
     display: flex;
     align-items: center;
     height: 72px;
+    min-height: 72px;
     padding: 0 24px;
     font-weight: 600;
     font-size: 16px;

--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -6,7 +6,7 @@ import AsyncSelect from 'react-select/async';
 import Select from 'react-select';
 
 export const BackstageHeader = styled.div`
-    padding: 24px 0 0 14px;
+    padding: 20px 0 0 31px;
 `;
 
 export const BackstageHeaderTitle = styled.div`


### PR DESCRIPTION
#### Summary
Set a minimum height on the headers of the playbook backstage edit screen to prevent their collapsing under flex rules.

Before:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/1023171/102117234-751c7780-3e14-11eb-911c-0e47157f557f.png">
<img width="382" alt="image" src="https://user-images.githubusercontent.com/1023171/102117271-806fa300-3e14-11eb-86fd-a19d8b4c8280.png">

After:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/1023171/102117704-02f86280-3e15-11eb-8f53-6ba6b771ebcf.png">

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-31240