### PR TITLE
MM-31242: fix unusual backstage shadows

### DIFF
--- a/webapp/src/components/assets/left_fade.tsx
+++ b/webapp/src/components/assets/left_fade.tsx
@@ -6,7 +6,7 @@ const LeftFade = styled.div`
     top: 85px;
     left: 0;
     height: 100%;
-    background: linear-gradient(90deg, var(--center-channel-bg) 0%, rgba(255, 255, 255, 0) 94.89%);
+    background: linear-gradient(90deg, var(--center-channel-bg) 0%, rgba(var(--center-channel-bg-rgb), 0) 94.89%);
     pointer-events: none;
     z-index: -1;
 `;

--- a/webapp/src/components/assets/right_fade.tsx
+++ b/webapp/src/components/assets/right_fade.tsx
@@ -7,7 +7,7 @@ const RightFade = styled.div`
     height: 100%;
     width: 188px;
     z-index: -1;
-    background: linear-gradient(270deg, var(--center-channel-bg),transparent 60%);
+    background: linear-gradient(270deg, var(--center-channel-bg), rgba(var(--center-channel-bg-rgb), 0) 60%);
     pointer-events: none;
 `;
 


### PR DESCRIPTION
#### Summary
Safari's treatment of `linear-gradient` has `transparent` meaning black transparent (namely `rgba(0,0,0,0)` -- [reference](https://stackoverflow.com/questions/30673204/css-linear-gradient-transparency-misbehaving-only-in-safari)).

This is apparently according to spec, but results in the undesirable behaviour below as we try to fade out the image assets in the backstage:
<img width="222" alt="image" src="https://user-images.githubusercontent.com/1023171/102119897-2f61ae00-3e18-11eb-9eca-25ab501c9d21.png">

Fix this by making a transparent version of the background colour over which to apply the gradient ([reference](https://stackoverflow.com/questions/30673204/css-linear-gradient-transparency-misbehaving-only-in-safari)):
<img width="249" alt="image" src="https://user-images.githubusercontent.com/1023171/102119984-4e604000-3e18-11eb-8030-841292adb581.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31242