### PR TITLE
MM-31243: broadcast channel tweaks

### DIFF
--- a/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
@@ -139,7 +139,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // # Open the broadcast channel widget and select a public channel
-            cy.findByTestId('playbook-preferences-broadcast-channel').click().type('off-topic{enter}');
+            cy.findByTestId('playbook-preferences-broadcast-channel').click().type('off-topic{enter}', {delay: 200});
 
             // # Save the playbook
             cy.findByTestId('save_playbook').click();
@@ -162,7 +162,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // # Open the broadcast channel widget and select a public channel
-            cy.findByTestId('playbook-preferences-broadcast-channel').click().type('autem-2{enter}');
+            cy.findByTestId('playbook-preferences-broadcast-channel').click().type('autem-2{enter}', {delay: 200});
 
             // # Save the playbook
             cy.findByTestId('save_playbook').click();
@@ -185,7 +185,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // # Open the broadcast channel widget and select the private channel
-            cy.findByTestId('playbook-preferences-broadcast-channel').click().type(privateChannelId + '{enter}');
+            cy.findByTestId('playbook-preferences-broadcast-channel').click().type(privateChannelId + '{enter}', {delay: 200});
 
             // # Save the playbook
             cy.findByTestId('save_playbook').click();

--- a/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
@@ -177,7 +177,7 @@ describe('backstage playbook details', () => {
             cy.findByTestId('playbook-preferences-broadcast-channel').should('have.text', 'commodi');
         });
 
-        it('shows "Unknown channel" when private broadcast channel configured and user it not a member', () => {
+        it('shows "Unknown channel" when private broadcast channel configured and user is not a member', () => {
             // # Visit the selected playbook
             cy.visit('/ad-1/com.mattermost.plugin-incident-management/playbooks/' + playbookId);
 

--- a/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
@@ -139,7 +139,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // # Open the broadcast channel widget and select a public channel
-            cy.findByTestId('playbook-preferences-broadcast-channel').click().type('off-topic{enter}', {delay: 200});
+            cy.findByTestId('playbook-preferences-broadcast-channel').click().type('saepe-5{enter}', {delay: 200});
 
             // # Save the playbook
             cy.findByTestId('save_playbook').click();
@@ -151,7 +151,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // * Verify placeholder text is present
-            cy.findByTestId('playbook-preferences-broadcast-channel').should('have.text', 'Off-Topic');
+            cy.findByTestId('playbook-preferences-broadcast-channel').should('have.text', 'doloremque');
         });
 
         it('shows channel name when private broadcast channel configured and user is a member', () => {

--- a/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
@@ -128,7 +128,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // * Verify placeholder text is present
-            cy.findByTestId('playbook-preferences-broadcast-channel').should('have.text', 'Select a channel');
+            cy.get('#playbook-preferences-broadcast-channel').should('have.text', 'Select a channel');
         });
 
         it('shows channel name when public broadcast channel configured', () => {
@@ -139,7 +139,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // # Open the broadcast channel widget and select a public channel
-            cy.findByTestId('playbook-preferences-broadcast-channel').click().type('saepe-5{enter}', {delay: 200});
+            cy.get('#playbook-preferences-broadcast-channel').click().type('saepe-5{enter}', {delay: 200});
 
             // # Save the playbook
             cy.findByTestId('save_playbook').click();
@@ -151,7 +151,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // * Verify placeholder text is present
-            cy.findByTestId('playbook-preferences-broadcast-channel').should('have.text', 'doloremque');
+            cy.get('#playbook-preferences-broadcast-channel').should('have.text', 'doloremque');
         });
 
         it('shows channel name when private broadcast channel configured and user is a member', () => {
@@ -162,7 +162,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // # Open the broadcast channel widget and select a public channel
-            cy.findByTestId('playbook-preferences-broadcast-channel').click().type('autem-2{enter}', {delay: 200});
+            cy.get('#playbook-preferences-broadcast-channel').click().type('autem-2{enter}', {delay: 200});
 
             // # Save the playbook
             cy.findByTestId('save_playbook').click();
@@ -174,7 +174,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // * Verify placeholder text is present
-            cy.findByTestId('playbook-preferences-broadcast-channel').should('have.text', 'commodi');
+            cy.get('#playbook-preferences-broadcast-channel').should('have.text', 'commodi');
         });
 
         it('shows "Unknown channel" when private broadcast channel configured and user is not a member', () => {
@@ -185,7 +185,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // # Open the broadcast channel widget and select the private channel
-            cy.findByTestId('playbook-preferences-broadcast-channel').click().type(privateChannelId + '{enter}', {delay: 200});
+            cy.get('#playbook-preferences-broadcast-channel').click().type(privateChannelId + '{enter}', {delay: 200});
 
             // # Save the playbook
             cy.findByTestId('save_playbook').click();
@@ -204,7 +204,7 @@ describe('backstage playbook details', () => {
             cy.get('#root').findByText('Preferences').click();
 
             // * Verify placeholder text is present
-            cy.findByTestId('playbook-preferences-broadcast-channel').should('have.text', 'Unknown Channel');
+            cy.get('#playbook-preferences-broadcast-channel').should('have.text', 'Unknown Channel');
         });
     });
 });

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -39,16 +39,16 @@ const ChannelSelector: FC<Props> = (props: Props) => {
     };
 
     const channelsLoader = (term: string, callback: (options: OptionsType<Channel>) => void) => {
-        callback(selectableChannels.filter((channel) => {
-            if (term.trim().length === 0) {
-                return true;
-            }
-
+        if (term.trim().length === 0) {
+            callback(selectableChannels);
+        } else {
             // Implement rudimentary channel name searches.
-            return channel.name.toLowerCase().includes(term.toLowerCase()) ||
-                channel.display_name.toLowerCase().includes(term.toLowerCase()) ||
-                channel.id.toLowerCase() === term.toLowerCase();
-        }));
+            callback(selectableChannels.filter((channel) => (
+                channel.name.toLowerCase().includes(term.toLowerCase()) ||
+                    channel.display_name.toLowerCase().includes(term.toLowerCase()) ||
+                    channel.id.toLowerCase() === term.toLowerCase()
+            )));
+        }
     };
 
     const value = props.playbook.broadcast_channel_id && getChannelFromID(props.playbook.broadcast_channel_id);

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -39,8 +39,19 @@ const ChannelSelector: FC<Props> = (props: Props) => {
     };
 
     const channelsLoader = (term: string, callback: (options: OptionsType<Channel>) => void) => {
-        callback(selectableChannels);
+        callback(selectableChannels.filter((channel) => {
+            if (term.trim().length === 0) {
+                return true;
+            }
+
+            // Implement rudimentary channel name searches.
+            return channel.name.toLowerCase().includes(term.toLowerCase()) ||
+                channel.display_name.toLowerCase().includes(term.toLowerCase()) ||
+                channel.id.toLowerCase() === term.toLowerCase();
+        }));
     };
+
+    const value = props.playbook.broadcast_channel_id && getChannelFromID(props.playbook.broadcast_channel_id);
 
     return (
         <StyledAsyncSelect
@@ -55,7 +66,7 @@ const ChannelSelector: FC<Props> = (props: Props) => {
             defaultMenuIsOpen={false}
             openMenuOnClick={true}
             isClearable={props.isClearable}
-            value={getChannelFromID(props.playbook.broadcast_channel_id)}
+            value={value}
             placeholder={'Select a channel'}
             classNamePrefix='channel-selector'
         />

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -11,6 +11,7 @@ import {Playbook} from 'src/types/playbook';
 import {StyledAsyncSelect} from './styles';
 
 export interface Props {
+    id?: string;
     onChannelSelected: (channelID: string | null) => void;
     playbook: Playbook;
     isClearable?: boolean;
@@ -55,6 +56,7 @@ const ChannelSelector: FC<Props> = (props: Props) => {
 
     return (
         <StyledAsyncSelect
+            id={props.id}
             isMulti={false}
             controlShouldRenderValue={true}
             cacheOptions={false}

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -393,13 +393,12 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
                                             {'Broadcast the incident status to an additional channel. All status posts will be shared automatically with both the incident and broadcast channel.'}
                                         </BackstageSubheaderDescription>
                                     </BackstageSubheaderText>
-                                    <div data-testid='playbook-preferences-broadcast-channel'>
-                                        <ChannelSelector
-                                            onChannelSelected={handleBroadcastInput}
-                                            playbook={playbook}
-                                            isClearable={true}
-                                        />
-                                    </div>
+                                    <ChannelSelector
+                                        id='playbook-preferences-broadcast-channel'
+                                        onChannelSelected={handleBroadcastInput}
+                                        playbook={playbook}
+                                        isClearable={true}
+                                    />
                                 </SidebarBlock>
                                 <SidebarBlock>
                                     <BackstageSubheaderText>

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -393,11 +393,13 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
                                             {'Broadcast the incident status to an additional channel. All status posts will be shared automatically with both the incident and broadcast channel.'}
                                         </BackstageSubheaderDescription>
                                     </BackstageSubheaderText>
-                                    <ChannelSelector
-                                        onChannelSelected={handleBroadcastInput}
-                                        playbook={playbook}
-                                        isClearable={true}
-                                    />
+                                    <div data-testid='playbook-preferences-broadcast-channel'>
+                                        <ChannelSelector
+                                            onChannelSelected={handleBroadcastInput}
+                                            playbook={playbook}
+                                            isClearable={true}
+                                        />
+                                    </div>
                                 </SidebarBlock>
                                 <SidebarBlock>
                                     <BackstageSubheaderText>


### PR DESCRIPTION
#### Summary
Keep showing `Unknown Channel` when a private channel is configured as the broadcast channel in the backstage, but restore showing `Select a channel` when none is selected at all.

As part of writing the unit tests here, I discovered it was impossible to type a channel name: search was broken. I restored this behaviour with a simple `includes` scan on id, name and display name.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-31243