### PR TITLE
[MM-31683] Fixing e2e and postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,110 +271,6 @@ jobs:
       - store_artifacts:
           path: tests-e2e/cypress/videos
 
-  e2e-cypress-tests-MM529:
-    resource_class: large
-    docker:
-      - image: circleci/golang:1.14.1-node-browsers
-        environment:
-          TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
-      - image: circleci/postgres:9.6.5-alpine-ram
-        environment:
-          POSTGRES_USER: mmuser
-          POSTGRES_PASSWORD: mostest
-          POSTGRES_DB: mattermost_test
-      - image: jhillyerd/inbucket:release-1.2.0
-      - image: minio/minio:RELEASE.2019-10-11T00-38-09Z
-        command: "server /data"
-        environment:
-          MINIO_ACCESS_KEY: minioaccesskey
-          MINIO_SECRET_KEY: miniosecretkey
-          MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
-      - image: mattermost/mattermost-elasticsearch-docker:6.5.1
-        environment:
-          http.host: "0.0.0.0"
-          http.port: 9200
-          http.cors.enabled: "true"
-          http.cors.allow-origin: "http://localhost:1358,http://127.0.0.1:1358"
-          http.cors.allow-headers: "X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
-          http.cors.allow-credentials: "true"
-          transport.host: "127.0.0.1"
-          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
-      - image: mattermost/mattermost-enterprise-edition:$MM_DOCKER_IMAGE_TAG
-        environment:
-          DB_HOST: localhost
-          DB_PORT_NUMBER: 5432
-          MM_DBNAME: mattermost_test
-          MM_USERNAME: mmuser
-          MM_PASSWORD: mostest
-          CI_INBUCKET_HOST: localhost
-          CI_INBUCKET_PORT: 10080
-          CI_MINIO_HOST: minio
-          IS_CI: true
-          MM_CLUSTERSETTINGS_READONLYCONFIG: false
-          MM_EMAILSETTINGS_SMTPSERVER: localhost
-          MM_EMAILSETTINGS_SMTPPORT: 10025
-          MM_ELASTICSEARCHSETTINGS_CONNECTIONURL: http://localhost:9200
-          MM_EXPERIMENTALSETTINGS_USENEWSAMLLIBRARY: true
-          MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
-          MM_SQLSETTINGS_DRIVERNAME: postgres
-          MM_PLUGINSETTINGS_ENABLEUPLOADS: true
-          MM_SERVICESETTINGS_SITEURL: http://localhost:8065
-    environment:
-      MM_DOCKER_IMAGE_TAG: 5.29.1
-      TYPE: NONE
-      PULL_REQUEST:
-      BROWSER: chrome
-      HEADLESS: true
-      DASHBOARD_ENABLE: false
-      FULL_REPORT: false
-      MM_SERVICESETTINGS_SITEURL: http://localhost:8065
-      MM_ADMIN_USERNAME: sysadmin
-      MM_ADMIN_PASSWORD: Sys@dmin-sample1
-    steps:
-      - setup_remote_docker
-      - run:
-          name: Wait for Inbucket
-          command: |
-            until curl --max-time 5 --output - localhost:10080; do echo waiting for Inbucket; sleep 5; done;
-      - run:
-          name: Wait for Elasticsearch
-          command: |
-            until curl --max-time 5 --output - localhost:9200; do echo waiting for Elasticsearch; sleep 5; done;
-      - checkout
-      - run:
-          name: Set and restore Postgres DB
-          command: |
-            whoami
-            sudo apt-get update
-            sudo apt-get install libxss1
-            sudo apt-get install postgresql-client
-            psql -d $TEST_DATABASE_URL -c "CREATE DATABASE migrated;"
-            psql -d $TEST_DATABASE_URL -c "CREATE DATABASE latest;"
-            psql -d $TEST_DATABASE_URL mattermost_test < tests-e2e/db-setup/test_data.sql
-      - run:
-          name: Upload license
-          command: |
-            TOKEN=`curl -i -d '{"login_id":"'${MM_ADMIN_USERNAME}'","password":"'${MM_ADMIN_PASSWORD}'"}' $MM_SERVICESETTINGS_SITEURL/api/v4/users/login | grep Token | cut -d' ' -f2`
-            TOKEN=${TOKEN//$'\r'/}
-            STATUSCODE=$(curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"trialreceive_emails_accepted": true, "terms_accepted": true, "users": 100}' $MM_SERVICESETTINGS_SITEURL/api/v4/trial-license -w "%{http_code}" -o /dev/stderr)
-            if test $STATUSCODE -ne 200; then exit 1; fi
-      - *restore_deploy_cache
-      - run:
-          name: Install Incident Management plugin
-          command: make deploy
-      - *save_deploy_cache
-      - *restore_cypress_cache
-      - run:
-          name: Run Cypress Tests
-          no_output_timeout: 30m
-          command: |
-            export FAILURE_MESSAGE="At least one test has failed."
-            export RESULTS_OUTPUT="results-output.txt"
-            cd tests-e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
-      - *save_cypress_cache
-      - store_artifacts:
-          path: tests-e2e/cypress/videos
-
 workflows:
   version: 2
   ci:
@@ -403,10 +299,6 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - e2e-cypress-tests-MM529:
-          filters:
-            tags:
-              only: /^v.*/
       - plugin-ci/build:
           context: mattermost-plugin-incident-response-production
           filters:
@@ -424,7 +316,6 @@ workflows:
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
             - e2e-cypress-tests
-            - e2e-cypress-tests-MM529
             - plugin-ci/build
       - plugin-ci/deploy-release:
           filters:
@@ -440,7 +331,6 @@ workflows:
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
             - e2e-cypress-tests
-            - e2e-cypress-tests-MM529
             - plugin-ci/build
       - plugin-ci/deploy-release-github:
           filters:
@@ -456,5 +346,4 @@ workflows:
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
             - e2e-cypress-tests
-            - e2e-cypress-tests-MM529
             - plugin-ci/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,7 @@ jobs:
           MM_SQLSETTINGS_DRIVERNAME: postgres
           MM_PLUGINSETTINGS_ENABLEUPLOADS: true
           MM_SERVICESETTINGS_SITEURL: http://localhost:8065
+          MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS: false
     environment:
       MM_DOCKER_IMAGE_TAG: master
       TYPE: NONE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
   test-MySQL57-Postgres10:
     docker:
       - image: circleci/golang:1.14.1-node
-      - image: circleci/postgres:10.9-alpine
+      - image: circleci/postgres:10-alpine
         environment:
           POSTGRES_USER: mmuser
           POSTGRES_DB: mattermost_test
@@ -103,7 +103,7 @@ jobs:
   test-MySQL8-Postgres11:
     docker:
       - image: circleci/golang:1.14.1-node
-      - image: circleci/postgres:11.6-alpine
+      - image: circleci/postgres:11-alpine
         environment:
           POSTGRES_USER: mmuser
           POSTGRES_DB: mattermost_test
@@ -173,7 +173,7 @@ jobs:
       - image: circleci/golang:1.14.1-node-browsers
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
-      - image: circleci/postgres:10.9-alpine-ram
+      - image: circleci/postgres:10-alpine-ram
         environment:
           POSTGRES_USER: mmuser
           POSTGRES_PASSWORD: mostest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
       - image: circleci/golang:1.14.1-node-browsers
         environment:
           TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
-      - image: circleci/postgres:9.6.5-alpine-ram
+      - image: circleci/postgres:10.9-alpine-ram
         environment:
           POSTGRES_USER: mmuser
           POSTGRES_PASSWORD: mostest
@@ -271,6 +271,110 @@ jobs:
       - store_artifacts:
           path: tests-e2e/cypress/videos
 
+  e2e-cypress-tests-MM529:
+    resource_class: large
+    docker:
+      - image: circleci/golang:1.14.1-node-browsers
+        environment:
+          TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
+      - image: circleci/postgres:9.6.5-alpine-ram
+        environment:
+          POSTGRES_USER: mmuser
+          POSTGRES_PASSWORD: mostest
+          POSTGRES_DB: mattermost_test
+      - image: jhillyerd/inbucket:release-1.2.0
+      - image: minio/minio:RELEASE.2019-10-11T00-38-09Z
+        command: "server /data"
+        environment:
+          MINIO_ACCESS_KEY: minioaccesskey
+          MINIO_SECRET_KEY: miniosecretkey
+          MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
+      - image: mattermost/mattermost-elasticsearch-docker:6.5.1
+        environment:
+          http.host: "0.0.0.0"
+          http.port: 9200
+          http.cors.enabled: "true"
+          http.cors.allow-origin: "http://localhost:1358,http://127.0.0.1:1358"
+          http.cors.allow-headers: "X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
+          http.cors.allow-credentials: "true"
+          transport.host: "127.0.0.1"
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      - image: mattermost/mattermost-enterprise-edition:$MM_DOCKER_IMAGE_TAG
+        environment:
+          DB_HOST: localhost
+          DB_PORT_NUMBER: 5432
+          MM_DBNAME: mattermost_test
+          MM_USERNAME: mmuser
+          MM_PASSWORD: mostest
+          CI_INBUCKET_HOST: localhost
+          CI_INBUCKET_PORT: 10080
+          CI_MINIO_HOST: minio
+          IS_CI: true
+          MM_CLUSTERSETTINGS_READONLYCONFIG: false
+          MM_EMAILSETTINGS_SMTPSERVER: localhost
+          MM_EMAILSETTINGS_SMTPPORT: 10025
+          MM_ELASTICSEARCHSETTINGS_CONNECTIONURL: http://localhost:9200
+          MM_EXPERIMENTALSETTINGS_USENEWSAMLLIBRARY: true
+          MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+          MM_SQLSETTINGS_DRIVERNAME: postgres
+          MM_PLUGINSETTINGS_ENABLEUPLOADS: true
+          MM_SERVICESETTINGS_SITEURL: http://localhost:8065
+    environment:
+      MM_DOCKER_IMAGE_TAG: 5.29.1
+      TYPE: NONE
+      PULL_REQUEST:
+      BROWSER: chrome
+      HEADLESS: true
+      DASHBOARD_ENABLE: false
+      FULL_REPORT: false
+      MM_SERVICESETTINGS_SITEURL: http://localhost:8065
+      MM_ADMIN_USERNAME: sysadmin
+      MM_ADMIN_PASSWORD: Sys@dmin-sample1
+    steps:
+      - setup_remote_docker
+      - run:
+          name: Wait for Inbucket
+          command: |
+            until curl --max-time 5 --output - localhost:10080; do echo waiting for Inbucket; sleep 5; done;
+      - run:
+          name: Wait for Elasticsearch
+          command: |
+            until curl --max-time 5 --output - localhost:9200; do echo waiting for Elasticsearch; sleep 5; done;
+      - checkout
+      - run:
+          name: Set and restore Postgres DB
+          command: |
+            whoami
+            sudo apt-get update
+            sudo apt-get install libxss1
+            sudo apt-get install postgresql-client
+            psql -d $TEST_DATABASE_URL -c "CREATE DATABASE migrated;"
+            psql -d $TEST_DATABASE_URL -c "CREATE DATABASE latest;"
+            psql -d $TEST_DATABASE_URL mattermost_test < tests-e2e/db-setup/test_data.sql
+      - run:
+          name: Upload license
+          command: |
+            TOKEN=`curl -i -d '{"login_id":"'${MM_ADMIN_USERNAME}'","password":"'${MM_ADMIN_PASSWORD}'"}' $MM_SERVICESETTINGS_SITEURL/api/v4/users/login | grep Token | cut -d' ' -f2`
+            TOKEN=${TOKEN//$'\r'/}
+            STATUSCODE=$(curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"trialreceive_emails_accepted": true, "terms_accepted": true, "users": 100}' $MM_SERVICESETTINGS_SITEURL/api/v4/trial-license -w "%{http_code}" -o /dev/stderr)
+            if test $STATUSCODE -ne 200; then exit 1; fi
+      - *restore_deploy_cache
+      - run:
+          name: Install Incident Management plugin
+          command: make deploy
+      - *save_deploy_cache
+      - *restore_cypress_cache
+      - run:
+          name: Run Cypress Tests
+          no_output_timeout: 30m
+          command: |
+            export FAILURE_MESSAGE="At least one test has failed."
+            export RESULTS_OUTPUT="results-output.txt"
+            cd tests-e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
+      - *save_cypress_cache
+      - store_artifacts:
+          path: tests-e2e/cypress/videos
+
 workflows:
   version: 2
   ci:
@@ -299,6 +403,10 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - e2e-cypress-tests-MM529:
+          filters:
+            tags:
+              only: /^v.*/
       - plugin-ci/build:
           context: mattermost-plugin-incident-response-production
           filters:
@@ -316,6 +424,7 @@ workflows:
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
             - e2e-cypress-tests
+            - e2e-cypress-tests-MM529
             - plugin-ci/build
       - plugin-ci/deploy-release:
           filters:
@@ -331,6 +440,7 @@ workflows:
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
             - e2e-cypress-tests
+            - e2e-cypress-tests-MM529
             - plugin-ci/build
       - plugin-ci/deploy-release-github:
           filters:
@@ -346,4 +456,5 @@ workflows:
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
             - e2e-cypress-tests
+            - e2e-cypress-tests-MM529
             - plugin-ci/build

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -94,6 +94,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // * Verify we see the welcome screen when there are no incidents
@@ -129,6 +132,9 @@ describe('rhs incident list', () => {
                 // # Click the incident icon
                 cy.get('#channel-header').within(() => {
                     cy.get('#incidentIcon').should('exist').click();
+
+                    // # Remove the Search dropdown that covers the rhs
+                    cy.get('#searchBox').click().type('{esc}');
                 });
 
                 // * Verify the rhs list is open the incident is visible.
@@ -161,6 +167,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # start 2 incidents
@@ -200,6 +209,9 @@ describe('rhs incident list', () => {
 
             // # Ensure the channel is loaded before continuing (allows redux to sync).
             cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Remove the Search dropdown that covers the rhs
+            cy.get('#searchBox').click().type('{esc}');
 
             // * Verify the incident RHS is open.
             cy.get('#rhsContainer').should('exist').within(() => {
@@ -261,6 +273,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // * Verify the rhs list is open and we can see the new incident
@@ -290,6 +305,9 @@ describe('rhs incident list', () => {
 
             // # Ensure the channel is loaded before continuing (allows redux to sync).
             cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Remove the Search dropdown that covers the rhs
+            cy.get('#searchBox').click().type('{esc}');
 
             // # Click the back button
             cy.get('#rhsContainer').within(() => {
@@ -329,6 +347,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // * Verify the rhs list is open and we can see the new incident
@@ -353,6 +374,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # start first incident
@@ -386,6 +410,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # start second incident
@@ -419,6 +446,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // * Verify the rhs list is open and only one incident is visible.
@@ -451,6 +481,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // * click on the first go-to-channel button.
@@ -490,6 +523,9 @@ describe('rhs incident list', () => {
 
             // # Ensure the channel is loaded before continuing (allows redux to sync).
             cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Remove the Search dropdown that covers the rhs
+            cy.get('#searchBox').click().type('{esc}');
 
             // * Verify the incident RHS is open.
             cy.get('#rhsContainer').should('exist').within(() => {
@@ -614,6 +650,9 @@ describe('rhs incident list', () => {
 
             // # Ensure the channel is loaded before continuing (allows redux to sync).
             cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Remove the Search dropdown that covers the rhs
+            cy.get('#searchBox').click().type('{esc}');
 
             // * Verify the incident RHS is open.
             cy.get('#rhsContainer').should('exist').within(() => {
@@ -769,6 +808,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # Login as user-2
@@ -816,6 +858,9 @@ describe('rhs incident list', () => {
             // # Ensure the channel is loaded before continuing (allows redux to sync).
             cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
 
+            // # Remove the Search dropdown that covers the rhs
+            cy.get('#searchBox').click().type('{esc}');
+
             // * Verify the incident RHS is open.
             cy.get('#rhsContainer').should('exist').within(() => {
                 cy.findByTestId('rhs-title').should('exist').within(() => {
@@ -847,6 +892,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # Login as user-2
@@ -949,6 +997,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # Login as user-2
@@ -1002,6 +1053,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # start new incident
@@ -1059,6 +1113,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // * Verify we can see the incidents list
@@ -1174,6 +1231,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # click the Start Incident link
@@ -1198,6 +1258,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # click the Start Incident link
@@ -1222,6 +1285,9 @@ describe('rhs incident list', () => {
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
                 cy.get('#incidentIcon').should('exist').click();
+
+                // # Remove the Search dropdown that covers the rhs
+                cy.get('#searchBox').click().type('{esc}');
             });
 
             // # click the Start Incident link
@@ -1256,6 +1322,9 @@ describe('rhs incident list', () => {
 
             // # Ensure the channel is loaded before continuing (allows redux to sync).
             cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Remove the Search dropdown that covers the rhs
+            cy.get('#searchBox').click().type('{esc}');
 
             // * Verify the incident RHS is open.
             cy.get('#rhsContainer').should('exist').within(() => {
@@ -1319,6 +1388,9 @@ describe('rhs incident list', () => {
 
                     // # Ensure the channel is loaded before continuing (allows redux to sync).
                     cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+                    // # Remove the Search dropdown that covers the rhs
+                    cy.get('#searchBox').click().type('{esc}');
 
                     // * Verify the incident RHS is open.
                     cy.get('#rhsContainer').should('exist').within(() => {

--- a/tests-e2e/cypress/integration/frontstage/slash_command/test_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/slash_command/test_spec.js
@@ -163,6 +163,9 @@ describe('slash command > test', () => {
                 // # Login as sysadmin.
                 cy.apiLogin('sysadmin');
 
+                // # Size the viewport to show the RHS without covering posts.
+                cy.viewport('macbook-13');
+
                 // # Navigate to a channel.
                 cy.visit('/ad-1/channels/town-square');
             });

--- a/tests-e2e/cypress/integration/frontstage/slash_command/test_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/slash_command/test_spec.js
@@ -355,7 +355,7 @@ describe('slash command > test', () => {
                     cy.executeSlashCommand('/incident test bulk-data 2 0 2020-01-01 2020-10-01 42');
 
                     // * Verify that the ephemeral message informs that the generation was successful.
-                    cy.verifyEphemeralMessage('The test data was successfully generated:');
+                    cy.verifyEphemeralMessage('The test data was successfully generated:', false, true);
 
                     // * Verify the number of created incidents is correct.
                     cy.getLastPostId().then((lastPostId) => {
@@ -370,7 +370,7 @@ describe('slash command > test', () => {
                     cy.executeSlashCommand('/incident test bulk-data 0 2 2020-01-01 2020-10-01 42');
 
                     // * Verify that the ephemeral message informs that the generation was successful.
-                    cy.verifyEphemeralMessage('The test data was successfully generated:');
+                    cy.verifyEphemeralMessage('The test data was successfully generated:', false, true);
 
                     // * Verify the number of created incidents is correct.
                     cy.getLastPostId().then((lastPostId) => {
@@ -385,7 +385,7 @@ describe('slash command > test', () => {
                     cy.executeSlashCommand('/incident test bulk-data 2 2 2020-01-01 2020-10-01 42');
 
                     // * Verify that the ephemeral message informs that the generation was successful
-                    cy.verifyEphemeralMessage('The test data was successfully generated:');
+                    cy.verifyEphemeralMessage('The test data was successfully generated:', false, true);
 
                     // * Verify the number of created incidents is correct.
                     cy.getLastPostId().then((lastPostId) => {

--- a/tests-e2e/cypress/support/ui_commands.js
+++ b/tests-e2e/cypress/support/ui_commands.js
@@ -96,6 +96,10 @@ Cypress.Commands.add('verifyPostedMessage', (message) => {
 // verifyEphemeralMessage verifies the receipt of an ephemeral message containing the given
 // message substring. An exact match is avoided to simplify tests.
 Cypress.Commands.add('verifyEphemeralMessage', (message, isCompactMode) => {
+    cy.get('#postListContent').within(() => {
+        cy.get('.post-list__dynamic').scrollTo('bottom');
+    });
+
     // # Checking if we got the ephemeral message with the selection we made
     cy.wait(TIMEOUTS.TINY).getLastPostId().then((postId) => {
         cy.get(`#post_${postId}`).within(() => {

--- a/tests-e2e/cypress/support/ui_commands.js
+++ b/tests-e2e/cypress/support/ui_commands.js
@@ -95,10 +95,13 @@ Cypress.Commands.add('verifyPostedMessage', (message) => {
 
 // verifyEphemeralMessage verifies the receipt of an ephemeral message containing the given
 // message substring. An exact match is avoided to simplify tests.
-Cypress.Commands.add('verifyEphemeralMessage', (message, isCompactMode) => {
-    cy.get('#postListContent').within(() => {
-        cy.get('.post-list__dynamic').scrollTo('bottom');
-    });
+Cypress.Commands.add('verifyEphemeralMessage', (message, isCompactMode, needsToScroll) => {
+    if (needsToScroll) {
+        // # Scroll the ephemeral message into view
+        cy.get('#postListContent').within(() => {
+            cy.get('.post-list__dynamic').scrollTo('bottom');
+        });
+    }
 
     // # Checking if we got the ephemeral message with the selection we made
     cy.wait(TIMEOUTS.TINY).getLastPostId().then((postId) => {


### PR DESCRIPTION
#### Summary
- upgraded postgres in the e2e tests
- added a bunch of little things to stop the e2e tests from failing. E.g., the "Search" bar and its drop down were activating after clicking on the incident-management channel header button, and hiding components below it. Why now? I don't know.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-31683