### PR TITLE
MM-31007: handle err fetching incident by channel

### DIFF
--- a/webapp/src/websocket_events.ts
+++ b/webapp/src/websocket_events.ts
@@ -91,8 +91,14 @@ export function handleWebsocketUserAdded(getState: GetStateFunc, dispatch: Dispa
         const currentUserId = getCurrentUserId(getState());
         const currentTeamId = getCurrentTeamId(getState());
         if (currentUserId === msg.data.user_id && currentTeamId === msg.data.team_id) {
-            const incident = await fetchIncidentByChannel(msg.broadcast.channel_id);
-            dispatch(receivedTeamIncidents([incident]));
+            try {
+                const incident = await fetchIncidentByChannel(msg.broadcast.channel_id);
+                dispatch(receivedTeamIncidents([incident]));
+            } catch (error) {
+                if (error.status_code !== 404) {
+                    throw error;
+                }
+            }
         }
     };
 }


### PR DESCRIPTION
#### Summary
When a user is added to a channel, we query the server to determine if this is an incident. If not, the client dutifully throws an 404 error, but we failed to handle that from the caller and treat it as a non-error. Fix this.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-31007
