### PR TITLE
MM-31919: set id when rendering Textbox

### DIFF
--- a/webapp/src/components/backstage/step_edit.tsx
+++ b/webapp/src/components/backstage/step_edit.tsx
@@ -4,7 +4,7 @@ import styled, {createGlobalStyle} from 'styled-components';
 
 import {ChecklistItem} from 'src/types/playbook';
 import {TertiaryButton} from 'src/components/assets/buttons';
-import {uniqueId} from 'src/utils';
+import {useUniqueId} from 'src/utils';
 
 import {StyledTextarea} from './styles';
 
@@ -236,7 +236,7 @@ const StepCommand: FC<StepCommandProps> = (props: StepCommandProps) => {
     const [focus, setFocus] = useState(false);
     const [hover, setHover] = useState(false);
     const ref = useRef(null);
-    const [id] = useState(uniqueId('step-command-'));
+    const id = useUniqueId('step-command-');
 
     useEffect(() => {
         if (focus && ref && ref.current) {

--- a/webapp/src/components/backstage/step_edit.tsx
+++ b/webapp/src/components/backstage/step_edit.tsx
@@ -1,10 +1,10 @@
 import React, {FC, useState, useRef, useEffect} from 'react';
 
 import styled, {createGlobalStyle} from 'styled-components';
-import uniqueId from 'lodash/uniqueId';
 
 import {ChecklistItem} from 'src/types/playbook';
 import {TertiaryButton} from 'src/components/assets/buttons';
+import {uniqueId} from 'src/utils';
 
 import {StyledTextarea} from './styles';
 

--- a/webapp/src/components/backstage/step_edit.tsx
+++ b/webapp/src/components/backstage/step_edit.tsx
@@ -1,6 +1,7 @@
 import React, {FC, useState, useRef, useEffect} from 'react';
 
 import styled, {createGlobalStyle} from 'styled-components';
+import uniqueId from 'lodash/uniqueId';
 
 import {ChecklistItem} from 'src/types/playbook';
 import {TertiaryButton} from 'src/components/assets/buttons';
@@ -235,6 +236,7 @@ const StepCommand: FC<StepCommandProps> = (props: StepCommandProps) => {
     const [focus, setFocus] = useState(false);
     const [hover, setHover] = useState(false);
     const ref = useRef(null);
+    const [id] = useState(uniqueId('step-command-'));
 
     useEffect(() => {
         if (focus && ref && ref.current) {
@@ -273,6 +275,7 @@ const StepCommand: FC<StepCommandProps> = (props: StepCommandProps) => {
             <OverrideWebappStyle/>
             <AutocompleteWrapper>
                 <AutocompleteTextbox
+                    id={id}
                     ref={ref}
                     inputComponent={StepInput}
                     createMessage={'Slash Command'}

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -1,0 +1,22 @@
+import {uniqueId} from './utils';
+
+describe('utils', () => {
+    describe('uniqueId', () => {
+        it('should handle a missing prefix', () => {
+            const id1 = uniqueId();
+            const id2 = uniqueId();
+
+            expect(id1).not.toEqual(id2);
+        });
+
+        it('should handle a prefix', () => {
+            const id1 = uniqueId('prefix');
+            const id2 = uniqueId('prefix');
+            const otherId1 = uniqueId('other');
+
+            expect(id1).not.toEqual(id2);
+            expect(id2).not.toEqual(otherId1);
+            expect(otherId1).not.toEqual(id1);
+        });
+    });
+});

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -1,0 +1,4 @@
+let idCounter = 0;
+
+// uniqueId generates a unique id with an optional prefix.
+export const uniqueId = (prefix = '') => prefix + String(++idCounter);

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -1,4 +1,15 @@
+import {useState} from 'react';
+
 let idCounter = 0;
 
 // uniqueId generates a unique id with an optional prefix.
-export const uniqueId = (prefix = '') => prefix + String(++idCounter);
+export const uniqueId = (prefix ?: string) => prefix + String(++idCounter);
+
+// useUniqueId exports a React hook simplifying the use of uniqueId.
+//
+// Note that changes to the prefix will not effect a change to the unique identifier.
+export const useUniqueId = (prefix ?: string) => {
+    const [id] = useState(() => uniqueId(prefix));
+
+    return id;
+};


### PR DESCRIPTION
#### Summary
The `Textbox` component from webapp requires an `id`, throwing an exception in development environments when we validate props at runtime.

This doesn't appear in a cloud/production environment, where runtime prop checking is disabled, and thus must be verified locally.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-31919