### PR TITLE
testing e2e with master & 5.31 mattermost docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
           command: make test
       - *save_test_cache
 
-  e2e-cypress-tests:
+  e2e-cypress-tests-master:
     resource_class: large
     docker:
       - image: circleci/golang:1.14.1-node-browsers
@@ -216,8 +216,115 @@ jobs:
           MM_PLUGINSETTINGS_ENABLEUPLOADS: true
           MM_SERVICESETTINGS_SITEURL: http://localhost:8065
           MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS: false
+          MM_ANNOUNCEMENTSETTINGS_ADMINNOTICESENABLED: false
     environment:
       MM_DOCKER_IMAGE_TAG: master
+      TYPE: NONE
+      PULL_REQUEST:
+      BROWSER: chrome
+      HEADLESS: true
+      DASHBOARD_ENABLE: false
+      FULL_REPORT: false
+      MM_SERVICESETTINGS_SITEURL: http://localhost:8065
+      MM_ADMIN_USERNAME: sysadmin
+      MM_ADMIN_PASSWORD: Sys@dmin-sample1
+    steps:
+      - setup_remote_docker
+      - run:
+          name: Wait for Inbucket
+          command: |
+            until curl --max-time 5 --output - localhost:10080; do echo waiting for Inbucket; sleep 5; done;
+      - run:
+          name: Wait for Elasticsearch
+          command: |
+            until curl --max-time 5 --output - localhost:9200; do echo waiting for Elasticsearch; sleep 5; done;
+      - checkout
+      - run:
+          name: Set and restore Postgres DB
+          command: |
+            whoami
+            sudo apt-get update
+            sudo apt-get install libxss1
+            sudo apt-get install postgresql-client
+            psql -d $TEST_DATABASE_URL -c "CREATE DATABASE migrated;"
+            psql -d $TEST_DATABASE_URL -c "CREATE DATABASE latest;"
+            psql -d $TEST_DATABASE_URL mattermost_test < tests-e2e/db-setup/test_data.sql
+      - run:
+          name: Upload license
+          command: |
+            TOKEN=`curl -i -d '{"login_id":"'${MM_ADMIN_USERNAME}'","password":"'${MM_ADMIN_PASSWORD}'"}' $MM_SERVICESETTINGS_SITEURL/api/v4/users/login | grep Token | cut -d' ' -f2`
+            TOKEN=${TOKEN//$'\r'/}
+            STATUSCODE=$(curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"trialreceive_emails_accepted": true, "terms_accepted": true, "users": 100}' $MM_SERVICESETTINGS_SITEURL/api/v4/trial-license -w "%{http_code}" -o /dev/stderr)
+            if test $STATUSCODE -ne 200; then exit 1; fi
+      - *restore_deploy_cache
+      - run:
+          name: Install Incident Management plugin
+          command: make deploy
+      - *save_deploy_cache
+      - *restore_cypress_cache
+      - run:
+          name: Run Cypress Tests
+          no_output_timeout: 30m
+          command: |
+            export FAILURE_MESSAGE="At least one test has failed."
+            export RESULTS_OUTPUT="results-output.txt"
+            cd tests-e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
+      - *save_cypress_cache
+      - store_artifacts:
+          path: tests-e2e/cypress/videos
+
+  e2e-cypress-tests-531:
+    resource_class: large
+    docker:
+      - image: circleci/golang:1.14.1-node-browsers
+        environment:
+          TEST_DATABASE_URL: postgres://mmuser:mostest@localhost:5432/mattermost_test
+      - image: circleci/postgres:10-alpine-ram
+        environment:
+          POSTGRES_USER: mmuser
+          POSTGRES_PASSWORD: mostest
+          POSTGRES_DB: mattermost_test
+      - image: jhillyerd/inbucket:release-1.2.0
+      - image: minio/minio:RELEASE.2019-10-11T00-38-09Z
+        command: "server /data"
+        environment:
+          MINIO_ACCESS_KEY: minioaccesskey
+          MINIO_SECRET_KEY: miniosecretkey
+          MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
+      - image: mattermost/mattermost-elasticsearch-docker:6.5.1
+        environment:
+          http.host: "0.0.0.0"
+          http.port: 9200
+          http.cors.enabled: "true"
+          http.cors.allow-origin: "http://localhost:1358,http://127.0.0.1:1358"
+          http.cors.allow-headers: "X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
+          http.cors.allow-credentials: "true"
+          transport.host: "127.0.0.1"
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      - image: mattermost/mattermost-enterprise-edition:$MM_DOCKER_IMAGE_TAG
+        environment:
+          DB_HOST: localhost
+          DB_PORT_NUMBER: 5432
+          MM_DBNAME: mattermost_test
+          MM_USERNAME: mmuser
+          MM_PASSWORD: mostest
+          CI_INBUCKET_HOST: localhost
+          CI_INBUCKET_PORT: 10080
+          CI_MINIO_HOST: minio
+          IS_CI: true
+          MM_CLUSTERSETTINGS_READONLYCONFIG: false
+          MM_EMAILSETTINGS_SMTPSERVER: localhost
+          MM_EMAILSETTINGS_SMTPPORT: 10025
+          MM_ELASTICSEARCHSETTINGS_CONNECTIONURL: http://localhost:9200
+          MM_EXPERIMENTALSETTINGS_USENEWSAMLLIBRARY: true
+          MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+          MM_SQLSETTINGS_DRIVERNAME: postgres
+          MM_PLUGINSETTINGS_ENABLEUPLOADS: true
+          MM_SERVICESETTINGS_SITEURL: http://localhost:8065
+          MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS: false
+          MM_ANNOUNCEMENTSETTINGS_ADMINNOTICESENABLED: false
+    environment:
+      MM_DOCKER_IMAGE_TAG: 5.31.0
       TYPE: NONE
       PULL_REQUEST:
       BROWSER: chrome
@@ -296,7 +403,11 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - e2e-cypress-tests:
+      - e2e-cypress-tests-master:
+          filters:
+            tags:
+              only: /^v.*/
+      - e2e-cypress-tests-531:
           filters:
             tags:
               only: /^v.*/
@@ -316,7 +427,7 @@ workflows:
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
-            - e2e-cypress-tests
+            - e2e-cypress-tests-531
             - plugin-ci/build
       - plugin-ci/deploy-release:
           filters:
@@ -331,7 +442,7 @@ workflows:
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
-            - e2e-cypress-tests
+            - e2e-cypress-tests-531
             - plugin-ci/build
       - plugin-ci/deploy-release-github:
           filters:
@@ -346,5 +457,5 @@ workflows:
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
             - test-MySQL-Postgres-latest
-            - e2e-cypress-tests
+            - e2e-cypress-tests-531
             - plugin-ci/build


### PR DESCRIPTION
#### Summary
- (as described in channel) This 'fixes' the e2e test problems we've been having. A lot (all?) of the e2e trouble Christopher was having on #429 was because of recent changes to master. I'm not sure what made so many (~27) tests fail, but it has caused a lot of wasted engineering effort. I can't tell if this will be fixed by moving to the cloud prerelease docker image (I'm waiting on devops to help us get it working). But after adding e2e test suites for 5.31, everything passes (after disabling those admin "upgrade your server" notices).

So, my proposed solution is to:
- e2e test with master (for now, until we move to the cloud prerelease image), which will fail
- e2e test with 5.31, which will pass
-  Christopher is going to turn off the requirement that all tests pass before merging, at least until we come up with a more permanent solution
- As long as 5.31 e2e tests pass, we are "okay" to merge a PR

- As for #429, I chatted with Christopher and after this current PR is in, he will merge and put back all the e2e tests and at least making sure they pass on 5.31. We don't want to remove e2e tests, considering how much time we've taken to build them.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-32233
