### PR TITLE
Add telemetry on reminder and broadcast features

### DIFF
--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -147,6 +147,7 @@ func (t *RudderTelemetry) ChangeCommander(incdnt *incident.Incident, userID stri
 func (t *RudderTelemetry) UpdateStatus(incdnt *incident.Incident, userID string) {
 	properties := incidentProperties(incdnt, userID)
 	properties["Action"] = actionUpdateStatus
+	properties["ReminderTimerSeconds"] = int(incdnt.PreviousReminder)
 	t.track(eventIncident, properties)
 }
 
@@ -228,14 +229,17 @@ func playbookProperties(pbook playbook.Playbook, userID string) map[string]inter
 	}
 
 	return map[string]interface{}{
-		"UserActualID":        userID,
-		"PlaybookID":          pbook.ID,
-		"TeamID":              pbook.TeamID,
-		"NumChecklists":       len(pbook.Checklists),
-		"TotalChecklistItems": totalChecklistItems,
-		"IsPublic":            pbook.CreatePublicIncident,
-		"NumMembers":          len(pbook.MemberIDs),
-		"NumSlashCommands":    totalChecklistItemsWithCommands,
+		"UserActualID":                userID,
+		"PlaybookID":                  pbook.ID,
+		"TeamID":                      pbook.TeamID,
+		"NumChecklists":               len(pbook.Checklists),
+		"TotalChecklistItems":         totalChecklistItems,
+		"IsPublic":                    pbook.CreatePublicIncident,
+		"NumMembers":                  len(pbook.MemberIDs),
+		"NumSlashCommands":            totalChecklistItemsWithCommands,
+		"ReminderTimerDefaultSeconds": pbook.ReminderTimerDefaultSeconds,
+		"BroadcastChannelID":          pbook.BroadcastChannelID,
+		"UsesReminderMessageTemplate": pbook.ReminderMessageTemplate != "",
 	}
 }
 


### PR DESCRIPTION
#### Summary
Add missing information in the telemetry data.

@Adovenmuehle, one of the fields I just added to the incident structure (`ReminderTimerSeconds`) is only present in a specific event, as it does not make much sense to send it with the others that relate to incidents. Is that ok for your data processing, or do you guys need us to always add the same fields for the events that refer to the same data type?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32051
