### PR TITLE
MM-32357 Telemetry for timeline tab

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -936,7 +936,7 @@ func (h *IncidentHandler) telemetryForIncident(w http.ResponseWriter, r *http.Re
 	h.telemetry.FrontendTelemetryForIncident(incdnt, userID, action, props)
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status":"OK"}`))
+	_, _ = w.Write([]byte(`{"status":"OK"}`))
 }
 
 func (h *IncidentHandler) postIncidentCreatedMessage(incdnt *incident.Incident, channelID string) error {

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -22,6 +22,7 @@ import (
 	mock_incident "github.com/mattermost/mattermost-plugin-incident-management/server/incident/mocks"
 	"github.com/mattermost/mattermost-plugin-incident-management/server/playbook"
 	mock_playbook "github.com/mattermost/mattermost-plugin-incident-management/server/playbook/mocks"
+	"github.com/mattermost/mattermost-plugin-incident-management/server/telemetry"
 )
 
 func TestIncidents(t *testing.T) {
@@ -33,6 +34,7 @@ func TestIncidents(t *testing.T) {
 	var incidentService *mock_incident.MockService
 	var pluginAPI *plugintest.API
 	var client *pluginapi.Client
+	telemetryService := &telemetry.NoopTelemetry{}
 
 	reset := func() {
 		mockCtrl = gomock.NewController(t)
@@ -43,7 +45,8 @@ func TestIncidents(t *testing.T) {
 		incidentService = mock_incident.NewMockService(mockCtrl)
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
-		NewIncidentHandler(handler.APIRouter, incidentService, playbookService, client, poster, logger)
+		telemetryService = &telemetry.NoopTelemetry{}
+		NewIncidentHandler(handler.APIRouter, incidentService, playbookService, client, poster, logger, telemetryService)
 	}
 
 	t.Run("create valid incident from dialog", func(t *testing.T) {

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -361,7 +361,7 @@ type Telemetry interface {
 	UpdateStatus(incident *Incident, userID string)
 
 	// FrontendTelemetryForIncident tracks an event originating from the frontend
-	FrontendTelemetryForIncident(incdnt *Incident, userID, action string, props map[string]string)
+	FrontendTelemetryForIncident(incdnt *Incident, userID, action string)
 
 	// ModifyCheckedState tracks the checking and unchecking of items.
 	ModifyCheckedState(incidentID, userID, newState string, wasCommander, wasAssignee bool)

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -360,6 +360,9 @@ type Telemetry interface {
 	// UpdateStatus tracks when an incident's status has been updated
 	UpdateStatus(incident *Incident, userID string)
 
+	// FrontendTelemetryForIncident tracks an event originating from the frontend
+	FrontendTelemetryForIncident(incdnt *Incident, userID, action string, props map[string]string)
+
 	// ModifyCheckedState tracks the checking and unchecking of items.
 	ModifyCheckedState(incidentID, userID, newState string, wasCommander, wasAssignee bool)
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -165,7 +165,15 @@ func (p *Plugin) OnActivate() error {
 	p.subscriptionService = subscription.NewService(pluginkvstore.NewSubscriptionStore(&pluginAPIClient.KV))
 
 	api.NewPlaybookHandler(p.handler.APIRouter, p.playbookService, pluginAPIClient, p.bot)
-	api.NewIncidentHandler(p.handler.APIRouter, p.incidentService, p.playbookService, pluginAPIClient, p.bot, p.bot)
+	api.NewIncidentHandler(
+		p.handler.APIRouter,
+		p.incidentService,
+		p.playbookService,
+		pluginAPIClient,
+		p.bot,
+		p.bot,
+		telemetryClient,
+	)
 	api.NewSubscriptionHandler(p.handler.APIRouter, p.subscriptionService, p.playbookService, pluginAPIClient)
 
 	isTestingEnabled := false

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -34,6 +34,10 @@ func (t *NoopTelemetry) RestartIncident(*incident.Incident, string) {
 func (t *NoopTelemetry) UpdateStatus(*incident.Incident, string) {
 }
 
+// FrontendTelemetryForIncident does nothing
+func (t *NoopTelemetry) FrontendTelemetryForIncident(incdnt *incident.Incident, userID, action string, props map[string]string) {
+}
+
 // AddTask does nothing.
 func (t *NoopTelemetry) AddTask(string, string) {
 }

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -35,7 +35,7 @@ func (t *NoopTelemetry) UpdateStatus(*incident.Incident, string) {
 }
 
 // FrontendTelemetryForIncident does nothing
-func (t *NoopTelemetry) FrontendTelemetryForIncident(incdnt *incident.Incident, userID, action string, props map[string]string) {
+func (t *NoopTelemetry) FrontendTelemetryForIncident(incdnt *incident.Incident, userID, action string) {
 }
 
 // AddTask does nothing.

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -152,12 +152,9 @@ func (t *RudderTelemetry) UpdateStatus(incdnt *incident.Incident, userID string)
 	t.track(eventIncident, properties)
 }
 
-func (t *RudderTelemetry) FrontendTelemetryForIncident(incdnt *incident.Incident, userID, action string, props map[string]string) {
+func (t *RudderTelemetry) FrontendTelemetryForIncident(incdnt *incident.Incident, userID, action string) {
 	properties := incidentProperties(incdnt, userID)
 	properties["Action"] = action
-	for k, v := range props {
-		properties[k] = v
-	}
 	t.track(eventFrontend, properties)
 }
 

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -42,6 +42,8 @@ const (
 	eventPlaybook = "playbook"
 	actionUpdate  = "update"
 	actionDelete  = "delete"
+
+	eventFrontend = "frontend"
 )
 
 // NewRudder builds a new RudderTelemetry client that will send the events to
@@ -148,6 +150,15 @@ func (t *RudderTelemetry) UpdateStatus(incdnt *incident.Incident, userID string)
 	properties := incidentProperties(incdnt, userID)
 	properties["Action"] = actionUpdateStatus
 	t.track(eventIncident, properties)
+}
+
+func (t *RudderTelemetry) FrontendTelemetryForIncident(incdnt *incident.Incident, userID, action string, props map[string]string) {
+	properties := incidentProperties(incdnt, userID)
+	properties["Action"] = action
+	for k, v := range props {
+		properties[k] = v
+	}
+	t.track(eventFrontend, properties)
 }
 
 func taskProperties(incidentID, userID string) map[string]interface{} {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -244,10 +244,9 @@ export async function clientReorderChecklist(incidentID: string, checklistNum: n
     return data;
 }
 
-export async function telemetryEventForIncident(incidentID: string, action: string, props?: Record<string, string>) {
-    const params = qs.stringify({action}, {addQueryPrefix: true});
-    const body = props ? JSON.stringify(props) : '';
-    await doPost(`${apiUrl}/telemetry/incident/${incidentID}${params}`, body);
+export async function telemetryEventForIncident(incidentID: string, action: string) {
+    const body = JSON.stringify({action});
+    await doPost(`${apiUrl}/telemetry/incident/${incidentID}`, body);
 }
 
 export function exportChannelUrl(channelId: string) {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -244,6 +244,12 @@ export async function clientReorderChecklist(incidentID: string, checklistNum: n
     return data;
 }
 
+export async function telemetryEventForIncident(incidentID: string, action: string, props?: Record<string, string>) {
+    const params = qs.stringify({action}, {addQueryPrefix: true});
+    const body = props ? JSON.stringify(props) : '';
+    await doPost(`${apiUrl}/telemetry/incident/${incidentID}${params}`, body);
+}
+
 export function exportChannelUrl(channelId: string) {
     const exportPluginUrl = '/plugins/com.mattermost.plugin-channel-export/api/v1';
 

--- a/webapp/src/components/rhs/rhs_tab_view.tsx
+++ b/webapp/src/components/rhs/rhs_tab_view.tsx
@@ -8,8 +8,10 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import {GlobalState} from 'mattermost-redux/types/store';
 
 import {RHSTabState} from 'src/types/rhs';
-import {currentRHSTabState} from 'src/selectors';
+import {currentIncident, currentRHSTabState} from 'src/selectors';
 import {setRHSTabState} from 'src/actions';
+import {Incident} from 'src/types/incident';
+import {telemetryEventForIncident} from 'src/client';
 
 const TabRow = styled.div`
     display: flex;
@@ -40,6 +42,7 @@ const RHSTabView = () => {
     const dispatch = useDispatch();
     const currentTabState = useSelector<GlobalState, RHSTabState>(currentRHSTabState);
     const channelId = useSelector<GlobalState, string>(getCurrentChannelId);
+    const incident = useSelector<GlobalState, Incident>(currentIncident);
 
     const setTabState = (nextState: RHSTabState) => {
         if (currentTabState !== nextState) {
@@ -65,7 +68,10 @@ const RHSTabView = () => {
             </TabItem>
             <TabItem
                 active={currentTabState === RHSTabState.ViewingTimeline}
-                onClick={() => setTabState(RHSTabState.ViewingTimeline)}
+                onClick={() => {
+                    setTabState(RHSTabState.ViewingTimeline);
+                    telemetryEventForIncident(incident.id, 'timeline_tab_clicked');
+                }}
                 data-testid='timeline'
             >
                 {'Timeline'}


### PR DESCRIPTION
#### Summary
- For v1 of Timelines, Jason wanted to have the ability to check whether or not people were using it.
- Added a `frontend` event (open to suggestions on naming) for all telemetry coming from the frontend. Added `timeline_tab_clicked` to record this one (also open to suggestions).
- Why not handle this on the frontend? I did at first, but I found I was duplicating the boilerplate info we want to have everywhere, and I wanted to be absolutely sure we were using the identical identifier ids, field names, etc. as the backend was sending, so I think it's easier if we do it this way. Less error prone.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-32357