### PR TITLE
MM-32516: selectively align profile selector to right

### DIFF
--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -311,6 +311,7 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                                 onCustomReset: resetAssignee,
                             }}
                             controlledOpenToggle={profileSelectorToggle}
+                            showOnRight={true}
                         />
                     </HoverMenu>
                 }

--- a/webapp/src/components/profile/profile_selector.scss
+++ b/webapp/src/components/profile/profile_selector.scss
@@ -11,6 +11,11 @@
         .incident-user-select__container {
             z-index: 2;
             position: absolute;
+        }
+    }
+
+    .profile-dropdown.show-on-right {
+        .incident-user-select__container {
             right: 0;
         }
     }

--- a/webapp/src/components/profile/profile_selector.tsx
+++ b/webapp/src/components/profile/profile_selector.tsx
@@ -40,6 +40,7 @@ interface Props {
     getUsers: () => Promise<UserProfile[]>;
     onSelectedChange: (userId?: string) => void;
     customControlProps?: any;
+    showOnRight?: boolean;
 }
 
 export default function ProfileSelector(props: Props) {
@@ -186,6 +187,7 @@ export default function ProfileSelector(props: Props) {
             isOpen={isOpen}
             onClose={toggleOpen}
             target={target}
+            showOnRight={props.showOnRight}
         >
             <ReactSelect
                 autoFocus={true}
@@ -228,13 +230,14 @@ const selectStyles: StylesConfig = {
 interface DropdownProps {
     children: JSX.Element;
     isOpen: boolean;
+    showOnRight?: boolean;
     target: JSX.Element;
     onClose: () => void;
 }
 
-const Dropdown = ({children, isOpen, target, onClose}: DropdownProps) => (
+const Dropdown = ({children, isOpen, showOnRight, target, onClose}: DropdownProps) => (
     <div
-        className={`IncidentFilter profile-dropdown${isOpen ? ' IncidentFilter--active profile-dropdown--active' : ''}`}
+        className={`IncidentFilter profile-dropdown${isOpen ? ' IncidentFilter--active profile-dropdown--active' : ''} ${showOnRight && 'show-on-right'}`}
         css={{position: 'relative'}}
     >
         {target}


### PR DESCRIPTION
#### Summary
To facilitate using the profile selector with the new "assignee" button, a `right: 0` property was unconditionally added. Unfortunately, this shifted all the profile selectors as such, causing problems for the commander dropdown when the RHS shrinks in size for smaller windows:

<img width="431" alt="image" src="https://user-images.githubusercontent.com/1023171/106760967-bbb77280-660a-11eb-997c-90a2f6f0f3ac.png">

<img width="800" alt="image" src="https://user-images.githubusercontent.com/1023171/106761031-cbcf5200-660a-11eb-8c5a-c311be7bfa6f.png">

<img width="427" alt="image" src="https://user-images.githubusercontent.com/1023171/106761001-c40fad80-660a-11eb-835c-1601868b4c92.png">

As a workaround, pass in a new `showOnRight` prop to conditionally set
this field:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/1023171/106761149-e86b8a00-660a-11eb-82d4-f05d6b1c1540.png">

<img width="799" alt="image" src="https://user-images.githubusercontent.com/1023171/106761188-f1f4f200-660a-11eb-8c32-e3a6a5c5c1ef.png">

<img width="424" alt="image" src="https://user-images.githubusercontent.com/1023171/106761217-f8836980-660a-11eb-8ac5-48b2051a37ef.png">

<img width="481" alt="image" src="https://user-images.githubusercontent.com/1023171/106761238-ff11e100-660a-11eb-9df8-4b84741f7e52.png">

Ideally, we'll revisit this component in the future.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-32516